### PR TITLE
Refactor evaluators into modular runners

### DIFF
--- a/evaluate_mesh.py
+++ b/evaluate_mesh.py
@@ -1,887 +1,109 @@
 #!/usr/bin/env python3
-"""
-Evaluate MESH - 60-minute swath predictions with multi-channel support
+"""Evaluate a model across the mesh test set using CSI metrics."""
+from __future__ import annotations
 
-Evaluates model predictions against the 60-minute MESH swath target.
-Supports models with 6 or 21 input channels.
-- For 6-channel models: uses first 6 channels from data
-- For 21-channel models: uses first 6 channels + expands to 21
-"""
-
-import os
-import json
+import argparse
 import logging
-import numpy as np
-import pandas as pd
-import boto3
-from io import BytesIO
-from datetime import datetime
-from typing import Dict, List, Optional, Tuple
+from typing import Optional
 
-# ---------------- TensorFlow / Keras & custom layers ----------------
-import tensorflow as tf
-from tensorflow import keras as tfk
-logger = logging.getLogger("evaluate_mesh_60min")
+from evaluation.config import MeshEvaluationConfig
+from evaluation.data import EvaluationDataRepository, NormalizationBundle, S3ArtifactLoader
+from evaluation.mesh_runner import MeshEvaluator
+from evaluation.models import ModelLoader
 
-# Import custom objects from modules
-try:
-    from rnn import (
-        reshape_and_stack, slice_to_n_steps, slice_output_shape,
-        ResBlock, WarmUpCosineDecayScheduler, ConvGRU, ConvBlock,
-        ZeroLikeLayer, ReflectionPadding2D, ResGRU, GRUResBlock
-    )
-    from models import weighted_mse, csi 
-    logger.info("Successfully imported custom objects from rnn and models modules")
-except ImportError as e:
-    logger.error(f"CRITICAL: Cannot import required modules - {e}")
-    raise ImportError("Required modules rnn.py and models.py not found.")
 
-# ---------------- Channel indices ----------------
-C_MESH60    = 0  # MESH_Max_60min (target channel)
-C_MESH      = 1  # MESH (raw)
-C_HCR       = 2  # HeightCompositeReflectivity
-C_ECHOTOP50 = 3  # EchoTop_50
-C_PRECIP    = 4  # PrecipRate
-C_REF0C     = 5  # Reflectivity_0C
-C_REFm20    = 6  # Reflectivity_-20C
-C_MESH_DIL  = 7  # MESH dil mask (binary)
-
-# First 6 channels for 6-channel models
-BASE_CHANNELS_6 = [C_MESH60, C_MESH, C_HCR, C_ECHOTOP50, C_PRECIP, C_REF0C]
-NORM_CHANNELS_6 = [C_MESH60, C_MESH, C_HCR, C_ECHOTOP50, C_PRECIP, C_REF0C]
-
-# 21-channel model uses first 6 + extended features
-NORM_CHANNELS_21 = list(range(21))  # Normalize all 21 channels
-
-# ---------------- Logging ----------------
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(levelname)s - %(message)s',
-    handlers=[logging.StreamHandler()]
-)
-logger = logging.getLogger("evaluate_mesh_60min")
-
-# ---------------- Config ----------------
-class Config:
-    # Buckets / paths
-    MODEL_BUCKET       = os.getenv('MODEL_BUCKET', 'dev-grib-bucket')
-    TEST_DF_BUCKET     = os.getenv('TEST_DF_BUCKET', MODEL_BUCKET)
-    MODEL_DIR          = os.getenv('MODEL_DIR', './models')  # Local directory containing models
-    MODEL_PATTERN      = os.getenv('MODEL_PATTERN', 'growth*/*/*.keras')  # Pattern within MODEL_DIR
-    TEST_DF_PATH       = os.getenv('TEST_DF_PATH', 'dataframes/test.csv')
-    NORMALIZATION_MIN_PATH = os.getenv('NORMALIZATION_MIN_PATH', 'global_mins.npy')
-    NORMALIZATION_MAX_PATH = os.getenv('NORMALIZATION_MAX_PATH', 'global_maxs.npy')
-
-    # Writable roots
-    RESULTS_ROOT      = os.getenv('RESULTS_ROOT', './evaluation_results')
-    MODEL_CACHE_ROOT  = os.getenv('MODEL_CACHE_ROOT', './model_cache')
-    DATA_CACHE_ROOT   = os.getenv('DATA_CACHE_ROOT', './data')
-
-    # Eval set
-    NUM_SAMPLES = int(os.getenv('NUM_SAMPLES', '100'))
-
-    # All timesteps (0-11) corresponding to 0-55 minutes in 5-minute intervals
-    TIMESTEPS = np.arange(0, 12)
-    
-    # Thresholds (mm)
-    OBS_THRESHOLDS = [5, 10, 20, 30, 40, 50, 70]
-    
-    # Prediction threshold search range
-    PRED_CUTOFF_MIN  = 1.0
-    PRED_CUTOFF_MAX  = 60.0
-    PRED_CUTOFF_STEP = 1.0
-
-    @property
-    def MODEL_NAME(self):
-        # Will be set dynamically per model
-        if hasattr(self, '_current_model_path'):
-            return os.path.splitext(os.path.basename(self._current_model_path))[0]
-        return 'unknown'
-    
-    @property
-    def RESULTS_DIR(self):
-        return os.path.join(self.RESULTS_ROOT, self.MODEL_NAME)
-    
-    def set_current_model(self, model_path: str):
-        """Set the current model path for property methods"""
-        self._current_model_path = model_path
-
-# ---------------- Local Model Discovery ----------------
-def find_local_models(model_dir: str, pattern: str) -> List[str]:
-    """
-    Find all model files locally matching the pattern.
-    
-    Args:
-        model_dir: Local directory containing models (e.g., './models')
-        pattern: Pattern like 'growth*/*/*.keras'
-    
-    Returns:
-        List of local file paths matching the pattern
-    """
-    import glob
-    
-    full_pattern = os.path.join(model_dir, pattern)
-    logger.info(f"Searching for models: {full_pattern}")
-    
-    models = glob.glob(full_pattern)
-    models = sorted(models)
-    
-    logger.info(f"Found {len(models)} models matching pattern")
-    return models
-
-def detect_model_channels_from_path(model_path: str) -> int:
-    """
-    Infer expected channels from model path.
-    
-    Rules:
-    - growth_actual, growth_all, growth_half: 21 channels (full feature set)
-    - growth, growth2: 6 channels (base features)
-    
-    Note: This is a heuristic and should be verified against actual model input shape.
-    """
-    path_lower = model_path.lower()
-    
-    if any(x in path_lower for x in ['growth_actual', 'growth_all', 'growth_half']):
-        return 21
-    elif any(x in path_lower for x in ['growth2', '/growth/']):
-        return 6
-    else:
-        # Default to 6 for unknown patterns
-        logger.warning(f"Cannot infer channels from path {model_path}, will use model's actual input shape")
+def parse_n_tiles(value: Optional[str]) -> Optional[int]:
+    if value is None:
         return None
+    lowered = value.strip().lower()
+    if lowered in {"", "all", "everything", "full", "max", "none", "*"}:
+        return None
+    try:
+        parsed = int(lowered)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("--n_tiles must be a positive integer or 'everything'") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("--n_tiles must be positive")
+    return parsed
 
-# ---------------- S3 Loader ----------------
-class DataLoader:
-    def __init__(self, s3, data_root: str):
-        self.s3 = s3
-        self.cache_dir = data_root
-        os.makedirs(self.cache_dir, exist_ok=True)
 
-    def _cache_path(self, bucket: str, key: str) -> str:
-        path = os.path.join(self.cache_dir, bucket, key)
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        return path
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model_path", required=True, help="Path to the model checkpoint to evaluate")
+    parser.add_argument("--model_type", choices=["convgru", "flow"], help="Explicitly specify the model type")
+    parser.add_argument("--n_tiles", type=parse_n_tiles, default=None,
+                        help="Number of tiles to evaluate from the dataframe")
+    parser.add_argument("--flow_steps", type=int, default=64,
+                        help="Euler integration steps for diffusion models")
+    parser.add_argument("--bucket", default="dev-grib-bucket", help="S3 bucket containing evaluation assets")
+    parser.add_argument("--test_df_key", default="dataframes/test.csv",
+                        help="S3 key for the dataframe listing evaluation tiles")
+    parser.add_argument("--norm_min_key", default="global_mins.npy", help="S3 key for global minima array")
+    parser.add_argument("--norm_max_key", default="global_maxs.npy", help="S3 key for global maxima array")
+    parser.add_argument("--cache_dir", default="./cache", help="Local directory for cached downloads")
+    parser.add_argument("--summary_dir", default="./evaluation_results", help="Directory for metrics summaries")
+    parser.add_argument("--no_save", action="store_true", help="Disable writing JSON summaries and plots")
+    parser.add_argument("--log_level", default="INFO", help="Logging level")
+    return parser
 
-    def load_numpy(self, bucket: str, key: str) -> Optional[np.ndarray]:
-        cp = self._cache_path(bucket, key)
-        if os.path.exists(cp):
-            try:
-                return np.load(cp, allow_pickle=False)
-            except Exception:
-                try: os.remove(cp)
-                except Exception: pass
-        try:
-            obj = self.s3.get_object(Bucket=bucket, Key=key)
-            data = obj['Body'].read()
-            with open(cp, 'wb') as f: f.write(data)
-            return np.load(BytesIO(data), allow_pickle=False)
-        except Exception as e:
-            logger.error(f"Failed to load numpy s3://{bucket}/{key}: {e}")
-            return None
 
-    def load_csv(self, bucket: str, key: str) -> Optional[pd.DataFrame]:
-        cp = self._cache_path(bucket, key.replace('/', '_'))
-        if os.path.exists(cp):
-            try:
-                return pd.read_csv(cp)
-            except Exception:
-                try: os.remove(cp)
-                except Exception: pass
-        try:
-            obj = self.s3.get_object(Bucket=bucket, Key=key)
-            data = obj['Body'].read()
-            df = pd.read_csv(BytesIO(data))
-            df.to_csv(cp, index=False)
-            return df
-        except Exception as e:
-            logger.error(f"Failed to load CSV s3://{bucket}/{key}: {e}")
-            return None
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
 
-    @staticmethod
-    def normalize_inputs(x: np.ndarray, gmins: np.ndarray, gmaxs: np.ndarray, 
-                        norm_channels: List[int]) -> np.ndarray:
-        """Normalize specified channels to ~[0,1]; others stay unchanged."""
-        x = x.astype(np.float32, copy=False)
-        T, H, W, C = x.shape
-        out = np.zeros_like(x, dtype=np.float32)
-        
-        for t in range(T):
-            for c in range(C):
-                arr = x[t, :, :, c]
-                if c in norm_channels and c < len(gmins):
-                    mn, mx = float(gmins[c]), float(gmaxs[c])
-                    if not np.isfinite(mn) or not np.isfinite(mx) or mx <= mn:
-                        mn = float(np.nanmin(arr)) if np.isfinite(np.nanmin(arr)) else 0.0
-                        mx = float(np.nanmax(arr)) if np.isfinite(np.nanmax(arr)) else (mn + 1.0)
-                        if mx <= mn: mx = mn + 1.0
-                    out[t, :, :, c] = np.clip((arr - mn) / (mx - mn + 1e-5), 1e-5, 1.0)
-                else:
-                    out[t, :, :, c] = arr
-        return out
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO),
+                        format="%(asctime)s - %(levelname)s - %(message)s")
 
-# ---------------- Channel Adapter ----------------
-def adapt_channels_for_model(x: np.ndarray, target_channels: int) -> np.ndarray:
-    """
-    Adapt input data to match model's expected channel count.
-    
-    Args:
-        x: Input array of shape (T, H, W, C)
-        target_channels: Number of channels the model expects (6, 8, or 21)
-    
-    Returns:
-        Array with shape (T, H, W, target_channels)
-    """
-    T, H, W, C = x.shape
-    
-    if C == target_channels:
-        return x
-    
-    if target_channels == 6:
-        # Use first 6 channels
-        logger.info(f"Adapting {C} channels → 6 channels (using first 6)")
-        return x[:, :, :, :6]
-    
-    elif target_channels == 8:
-        # Use all 8 channels from data
-        if C >= 8:
-            logger.info(f"Adapting {C} channels → 8 channels (using first 8)")
-            return x[:, :, :, :8]
-        else:
-            # Pad with zeros if we have fewer than 8
-            logger.info(f"Adapting {C} channels → 8 channels (using {C} + {8-C} zero channels)")
-            adapted = np.zeros((T, H, W, 8), dtype=x.dtype)
-            adapted[:, :, :, :C] = x
-            return adapted
-    
-    elif target_channels == 21:
-        # Use first 6 channels and pad with zeros to reach 21
-        logger.info(f"Adapting {C} channels → 21 channels (first 6 + 15 zero channels)")
-        adapted = np.zeros((T, H, W, 21), dtype=x.dtype)
-        # Copy first 6 channels
-        adapted[:, :, :, :6] = x[:, :, :, :6]
-        # Remaining 15 channels stay as zeros
-        return adapted
-    
-    else:
-        raise ValueError(f"Unsupported target_channels: {target_channels}. Only 6, 8, or 21 supported.")
+    config = MeshEvaluationConfig(
+        bucket=args.bucket,
+        test_df_key=args.test_df_key,
+        norm_min_key=args.norm_min_key,
+        norm_max_key=args.norm_max_key,
+        model_path=args.model_path,
+        model_type=args.model_type,
+        n_tiles=args.n_tiles,
+        flow_steps=args.flow_steps,
+        save_summary=not args.no_save,
+        summary_dir=args.summary_dir,
+    )
 
-def detect_model_channels(model) -> int:
-    """
-    Detect expected number of channels from model input shape.
-    
-    Args:
-        model: Loaded Keras model
-    
-    Returns:
-        Number of expected channels (6, 8, or 21)
-    """
-    input_shape = model.input_shape
-    
-    # Handle different input shape formats
-    if isinstance(input_shape, list):
-        # Multiple inputs - use first one
-        channels = input_shape[0][-1]
-    else:
-        # Single input
-        channels = input_shape[-1]
-    
-    logger.info(f"Detected model expects {channels} channels from input shape")
-    
-    return channels
+    loader = S3ArtifactLoader(cache_dir=args.cache_dir)
+    normalization = NormalizationBundle.from_loader(loader, config.bucket, config.norm_min_key, config.norm_max_key)
+    repository = EvaluationDataRepository(loader, config.bucket, config.test_df_key)
+    loaded_model = ModelLoader().load(config)
+    evaluator = MeshEvaluator(config, repository, normalization, loaded_model)
+    result = evaluator.evaluate()
 
-# ---------------- Metrics Calculation ----------------
-class MetricsCalculator:
-    """Calculate metrics for 60-minute swath predictions"""
-    
-    def __init__(self, pred_thresholds, obs_thresholds):
-        self.pred_thr = np.asarray(pred_thresholds, dtype=float)
-        self.obs_thr = np.asarray(obs_thresholds, dtype=float)
-        P, O = len(self.pred_thr), len(self.obs_thr)
-        
-        # Accumulate stats for each timestep separately
-        self.timestep_stats = {}
-        for t in range(12):
-            self.timestep_stats[t] = {
-                'tp': np.zeros((P, O), dtype=np.int64),
-                'fp': np.zeros((P, O), dtype=np.int64),
-                'fn': np.zeros((P, O), dtype=np.int64)
-            }
-        
-        # Also keep overall stats
-        self.overall_tp = np.zeros((P, O), dtype=np.int64)
-        self.overall_fp = np.zeros((P, O), dtype=np.int64)
-        self.overall_fn = np.zeros((P, O), dtype=np.int64)
+    print(f"Model type: {result['model_type']}")
+    print(f"Samples processed: {result['num_samples']}")
+    print(f"Successful: {result['successful']}, Failed: {result['failed']}")
 
-    def update(self, predictions: np.ndarray, target_60min: np.ndarray):
-        """Update metrics with a single sample's predictions and target."""
-        target = target_60min.ravel()
-        
-        # Process each timestep
-        for t in range(predictions.shape[0]):
-            pred_t = predictions[t].squeeze().ravel()
-            
-            for p_i, p_thr in enumerate(self.pred_thr):
-                pred_pos = pred_t >= p_thr
-                not_pred = ~pred_pos
-                
-                for o_i, o_thr in enumerate(self.obs_thr):
-                    obs_pos = target >= o_thr
-                    
-                    tp = int(np.count_nonzero(pred_pos & obs_pos))
-                    fp = int(np.count_nonzero(pred_pos & ~obs_pos))
-                    fn = int(np.count_nonzero(not_pred & obs_pos))
-                    
-                    self.timestep_stats[t]['tp'][p_i, o_i] += tp
-                    self.timestep_stats[t]['fp'][p_i, o_i] += fp
-                    self.timestep_stats[t]['fn'][p_i, o_i] += fn
-                    
-                    # Add to overall stats
-                    self.overall_tp[p_i, o_i] += tp
-                    self.overall_fp[p_i, o_i] += fp
-                    self.overall_fn[p_i, o_i] += fn
-
-    def compute_metrics(self, tp, fp, fn):
-        """Compute CSI, POD, FAR, and Bias from counts"""
-        denom = tp + fp + fn
-        with np.errstate(divide='ignore', invalid='ignore'):
-            csi = np.where(denom > 0, tp / denom, 0.0)
-            pod = np.where((tp + fn) > 0, tp / (tp + fn), 0.0)
-            far = np.where((tp + fp) > 0, fp / (tp + fp), 0.0)
-            bias = np.where((tp + fn) > 0, (tp + fp) / (tp + fn), 0.0)
-        return csi, pod, far, bias
-
-    def finalize(self):
-        """Compute final metrics for all timesteps and overall"""
-        results = {}
-        
-        # Compute metrics for each timestep
-        for t in range(12):
-            stats = self.timestep_stats[t]
-            csi, pod, far, bias = self.compute_metrics(stats['tp'], stats['fp'], stats['fn'])
-            
-            # Find best prediction threshold for each observation threshold
-            best_idx = np.argmax(csi, axis=0)
-            best_metrics = pd.DataFrame({
-                "obs_threshold": self.obs_thr,
-                "best_pred_threshold": self.pred_thr[best_idx],
-                "CSI": csi[best_idx, np.arange(len(self.obs_thr))],
-                "POD": pod[best_idx, np.arange(len(self.obs_thr))],
-                "FAR": far[best_idx, np.arange(len(self.obs_thr))],
-                "Bias": bias[best_idx, np.arange(len(self.obs_thr))]
-            })
-            
-            results[f'timestep_{t}'] = {
-                'minutes': t * 5,
-                'best_metrics': best_metrics.to_dict(orient='records'),
-                'csi_surface': csi.tolist(),
-                'pod_surface': pod.tolist(),
-                'far_surface': far.tolist(),
-                'bias_surface': bias.tolist()
-            }
-        
-        # Compute overall metrics (averaged across all timesteps)
-        overall_csi, overall_pod, overall_far, overall_bias = self.compute_metrics(
-            self.overall_tp / 12, self.overall_fp / 12, self.overall_fn / 12
+    overall = result["metrics"]["overall"]
+    print("=" * 60)
+    print("Overall CSI summary (best thresholds per observation):")
+    print(f"{'Obs Thr':>8} {'Best Pred':>10} {'CSI':>8} {'POD':>8} {'FAR':>8} {'Bias':>8}")
+    for record in overall.best_metrics:
+        print(
+            f"{record['obs_threshold']:>7.0f}mm {record['best_pred_threshold']:>9.1f}mm "
+            f"{record['CSI']:>8.3f} {record['POD']:>8.3f} {record['FAR']:>8.3f} {record['Bias']:>8.3f}"
         )
-        
-        best_idx_overall = np.argmax(overall_csi, axis=0)
-        best_overall = pd.DataFrame({
-            "obs_threshold": self.obs_thr,
-            "best_pred_threshold": self.pred_thr[best_idx_overall],
-            "CSI": overall_csi[best_idx_overall, np.arange(len(self.obs_thr))],
-            "POD": overall_pod[best_idx_overall, np.arange(len(self.obs_thr))],
-            "FAR": overall_far[best_idx_overall, np.arange(len(self.obs_thr))],
-            "Bias": overall_bias[best_idx_overall, np.arange(len(self.obs_thr))]
-        })
-        
-        results['overall'] = {
-            'best_metrics': best_overall.to_dict(orient='records'),
-            'csi_surface': overall_csi.tolist(),
-            'pod_surface': overall_pod.tolist(),
-            'far_surface': overall_far.tolist(),
-            'bias_surface': overall_bias.tolist()
-        }
-        
-        return results
 
-# ---------------- Evaluator ----------------
-class ModelEvaluator:
-    def __init__(self, cfg: Config):
-        self.cfg = cfg
-        self.s3 = boto3.client('s3')
-        self.loader = DataLoader(self.s3, cfg.DATA_CACHE_ROOT)
-        self.model = None
-        self.gmins = None
-        self.gmaxs = None
-        self.model_channels = None
-        self.current_model_path = None
-
-        os.makedirs(cfg.DATA_CACHE_ROOT, exist_ok=True)
-
-    def load_model(self, model_path: str) -> bool:
-        """Load a specific model from local filesystem"""
-        self.current_model_path = model_path
-        self.cfg.set_current_model(model_path)
-        
-        # Create results directory
-        os.makedirs(self.cfg.RESULTS_DIR, exist_ok=True)
-        
-        logger.info(f"Loading model from: {model_path}")
-        try:
-            if not os.path.exists(model_path):
-                logger.error(f"Model file not found: {model_path}")
-                return False
-
-            # Custom objects for model loading
-            custom_objects = {
-                'loss': weighted_mse(),
-                'weighted_mse': weighted_mse(),
-                'csi': csi,
-                'reshape_and_stack': reshape_and_stack,
-                'slice_to_n_steps': slice_to_n_steps,
-                'slice_output_shape': slice_output_shape,
-                'ResBlock': ResBlock,
-                'ConvBlock': ConvBlock,
-                'ZeroLikeLayer': ZeroLikeLayer,
-                'ReflectionPadding2D': ReflectionPadding2D,
-                'ConvGRU': ConvGRU,
-                'ResGRU': ResGRU,
-                'GRUResBlock': GRUResBlock,
-                'WarmUpCosineDecayScheduler': WarmUpCosineDecayScheduler,
-            }
-            
-            # Load model
-            self.model = tf.keras.models.load_model(model_path, custom_objects=custom_objects, compile=False)
-            
-            # Detect expected channels from model's actual input shape
-            self.model_channels = detect_model_channels(self.model)
-            
-            # Also check path-based inference for logging
-            expected_from_path = detect_model_channels_from_path(model_path)
-            if expected_from_path and self.model_channels != expected_from_path:
-                logger.warning(f"Channel mismatch: path suggests {expected_from_path}, model actually has {self.model_channels}")
-                logger.warning(f"Using model's actual channel count: {self.model_channels}")
-            
-            # Log model info
-            logger.info(f"Loaded model: {self.cfg.MODEL_NAME}")
-            logger.info(f"  Model path: {model_path}")
-            logger.info(f"  Input shape:  {self.model.input_shape}")
-            logger.info(f"  Output shape: {self.model.output_shape}")
-            logger.info(f"  Expected channels: {self.model_channels}")
-            logger.info(f"  Parameters:   {self.model.count_params():,}")
-            
-            return True
-        except Exception as e:
-            logger.error(f"Model load failed: {e}")
-            return False
-
-    def load_norm(self) -> bool:
-        self.gmins = self.loader.load_numpy(self.cfg.MODEL_BUCKET, self.cfg.NORMALIZATION_MIN_PATH)
-        self.gmaxs = self.loader.load_numpy(self.cfg.MODEL_BUCKET, self.cfg.NORMALIZATION_MAX_PATH)
-        ok = self.gmins is not None and self.gmaxs is not None
-        if not ok:
-            logger.error("Normalization params not found.")
-        else:
-            logger.info(f"Loaded normalization params: mins shape={self.gmins.shape}, maxs shape={self.gmaxs.shape}")
-        return ok
-
-    @staticmethod
-    def _resolve_paths_from_row(row: pd.Series) -> Optional[Tuple[str, str]]:
-        """Resolve input and target paths from dataframe row"""
-        target_key = None
-        for cand in ('target_path', 'target', 'y_path'):
-            if cand in row and isinstance(row[cand], str) and row[cand].strip():
-                target_key = row[cand].strip()
-                break
-
-        input_key = None
-        for cand in ('file_path', 'input_path', 'inputs_path', 'x_path'):
-            if cand in row and isinstance(row[cand], str) and row[cand].strip():
-                input_key = row[cand].strip()
-                break
-
-        if input_key is None and target_key is None:
-            return None
-
-        if target_key is None and input_key is not None:
-            if "/input/" in input_key:
-                target_key = input_key.replace("/input/", "/mesh_swath_intervals/")
-            elif "input/" in input_key:
-                target_key = input_key.replace("input/", "mesh_swath_intervals/")
-            else:
-                if "input" in input_key:
-                    suffix = input_key.split("input", 1)[1]
-                    target_key = f"data/int5/mesh_swath_intervals{suffix}"
-                else:
-                    base = os.path.basename(input_key)
-                    target_key = input_key.replace(base, f"mesh_swath_intervals_{base}")
-        
-        return input_key, target_key
-
-    def extract_60min_swath(self, target_array: np.ndarray) -> np.ndarray:
-        """Extract 60-minute MESH swath from target array."""
-        if target_array.ndim == 4:
-            return target_array[0, :, :, 0]
-        elif target_array.ndim == 3:
-            if target_array.shape[0] == 12:
-                return target_array[0, :, :]
-            else:
-                return target_array[:, :, 0]
-        elif target_array.ndim == 2:
-            return target_array
-        else:
-            logger.warning(f"Unexpected target shape: {target_array.shape}")
-            return target_array.squeeze()[:, :, 0] if target_array.shape[-1] > 1 else target_array.squeeze()
-
-    def evaluate(self) -> Dict:
-        df = self.loader.load_csv(self.cfg.TEST_DF_BUCKET, self.cfg.TEST_DF_PATH)
-        if df is None or df.empty:
-            logger.error("Empty test dataframe.")
-            return {}
-        
-        # Sample if needed
-        if len(df) > self.cfg.NUM_SAMPLES:
-            df = df.sample(self.cfg.NUM_SAMPLES, random_state=42)
-            logger.info(f"Sampled {self.cfg.NUM_SAMPLES} from {len(df)} total samples")
-        
-        logger.info(f"Evaluating {len(df)} samples against 60-minute MESH swath")
-        logger.info(f"Model expects {self.model_channels} channels")
-
-        # Setup metrics calculator
-        pred_cuts = np.arange(self.cfg.PRED_CUTOFF_MIN, self.cfg.PRED_CUTOFF_MAX + 1e-9, self.cfg.PRED_CUTOFF_STEP)
-        obs_thrs = np.array(self.cfg.OBS_THRESHOLDS, dtype=float)
-        
-        metrics_calc = MetricsCalculator(pred_cuts, obs_thrs)
-        
-        # Track statistics
-        successful_samples = 0
-        failed_samples = 0
-        prediction_stats = []
-        target_stats = []
-        
-        # Select normalization channels based on model
-        if self.model_channels == 21:
-            norm_channels = NORM_CHANNELS_21
-        elif self.model_channels == 8:
-            norm_channels = list(range(8))  # Normalize all 8 channels
-        else:  # 6 channels
-            norm_channels = NORM_CHANNELS_6
-        
-        # Main evaluation loop
-        for i, (idx, row) in enumerate(df.iterrows(), start=1):
-            if i % 20 == 0:
-                logger.info(f"Progress: {i}/{len(df)} samples")
-
-            resolved = self._resolve_paths_from_row(row)
-            if not resolved:
-                logger.warning(f"Row {idx}: could not resolve paths")
-                failed_samples += 1
-                continue
-            input_key, target_key = resolved
-
-            # Load data
-            x = self.loader.load_numpy(self.cfg.MODEL_BUCKET, input_key)
-            y = self.loader.load_numpy(self.cfg.MODEL_BUCKET, target_key)
-            if x is None or y is None:
-                logger.warning(f"Row {idx}: missing arrays")
-                failed_samples += 1
-                continue
-
-            # Extract 60-minute swath from target
-            target_60min = self.extract_60min_swath(y)
-            
-            # Process input
-            if x.ndim < 4:
-                x = np.expand_dims(x, -1)
-            x = x[::-1, :, :, :]  # reverse time
-            x = x[self.cfg.TIMESTEPS]
-            
-            # Log original shape
-            logger.debug(f"Original data shape: {x.shape}")
-            
-            # Adapt channels to match model requirements BEFORE normalization
-            x = adapt_channels_for_model(x, self.model_channels)
-            logger.debug(f"After adaptation shape: {x.shape}")
-            
-            # Normalize inputs
-            x = self.loader.normalize_inputs(x, self.gmins, self.gmaxs, norm_channels)
-            x[np.isnan(x)] = 0.0
-            target_60min[np.isnan(target_60min)] = 0.0
-
-            # Predict
-            try:
-                pred = self.model.predict(np.expand_dims(x, 0), verbose=0)
-                pred = pred[0]
-                successful_samples += 1
-            except Exception as e:
-                logger.error(f"Prediction failed for sample {idx}: {e}")
-                failed_samples += 1
-                continue
-
-            # Update metrics
-            metrics_calc.update(pred, target_60min)
-            
-            # Collect statistics
-            prediction_stats.append({
-                'min': float(np.min(pred)),
-                'max': float(np.max(pred)),
-                'mean': float(np.mean(pred)),
-                'std': float(np.std(pred))
-            })
-            target_stats.append({
-                'min': float(np.min(target_60min)),
-                'max': float(np.max(target_60min)),
-                'mean': float(np.mean(target_60min)),
-                'std': float(np.std(target_60min))
-            })
-
-        logger.info(f"Evaluation complete: {successful_samples} successful, {failed_samples} failed")
-
-        # Finalize metrics
-        metrics_results = metrics_calc.finalize()
-        
-        # Compute aggregate statistics
-        if prediction_stats:
-            agg_pred_stats = {
-                'min': float(np.mean([s['min'] for s in prediction_stats])),
-                'max': float(np.mean([s['max'] for s in prediction_stats])),
-                'mean': float(np.mean([s['mean'] for s in prediction_stats])),
-                'std': float(np.mean([s['std'] for s in prediction_stats]))
-            }
-        else:
-            agg_pred_stats = {'min': 0, 'max': 0, 'mean': 0, 'std': 0}
-        
-        if target_stats:
-            agg_target_stats = {
-                'min': float(np.mean([s['min'] for s in target_stats])),
-                'max': float(np.mean([s['max'] for s in target_stats])),
-                'mean': float(np.mean([s['mean'] for s in target_stats])),
-                'std': float(np.mean([s['std'] for s in target_stats]))
-            }
-        else:
-            agg_target_stats = {'min': 0, 'max': 0, 'mean': 0, 'std': 0}
-        
-        # Create final results
-        final_results = {
-            'model': self.cfg.MODEL_NAME,
-            'model_channels': self.model_channels,
-            'evaluation_datetime': datetime.utcnow().isoformat(),
-            'num_samples': len(df),
-            'successful_samples': successful_samples,
-            'failed_samples': failed_samples,
-            'target': '60-minute MESH swath',
-            'prediction_statistics': agg_pred_stats,
-            'target_statistics': agg_target_stats,
-            'metrics_by_timestep': metrics_results,
-            'observation_thresholds': self.cfg.OBS_THRESHOLDS,
-            'prediction_threshold_range': {
-                'min': self.cfg.PRED_CUTOFF_MIN,
-                'max': self.cfg.PRED_CUTOFF_MAX,
-                'step': self.cfg.PRED_CUTOFF_STEP
-            }
-        }
-        
-        # Print summary
-        self._print_summary(metrics_results)
-        
-        return final_results
-
-    def _print_summary(self, metrics_results):
-        """Print evaluation summary"""
-        logger.info("\n" + "="*80)
-        logger.info(f"EVALUATION SUMMARY - 60-MINUTE MESH SWATH ({self.model_channels} channels)")
-        logger.info("="*80)
-        
-        # Print overall metrics
-        overall = metrics_results['overall']['best_metrics']
-        logger.info("\nOVERALL METRICS (averaged across all timesteps):")
-        logger.info(f"{'Obs Thr':>8} {'Best Pred':>10} {'CSI':>8} {'POD':>8} {'FAR':>8} {'Bias':>8}")
-        logger.info("-" * 60)
-        for metric in overall:
-            logger.info(f"{metric['obs_threshold']:>7.0f}mm {metric['best_pred_threshold']:>9.1f}mm "
-                       f"{metric['CSI']:>8.3f} {metric['POD']:>8.3f} {metric['FAR']:>8.3f} {metric['Bias']:>8.2f}")
-        
-        # Print metrics for key timesteps
-        key_timesteps = [0, 6, 11]
-        for t in key_timesteps:
-            timestep_key = f'timestep_{t}'
-            if timestep_key in metrics_results:
-                minutes = metrics_results[timestep_key]['minutes']
-                metrics = metrics_results[timestep_key]['best_metrics']
-                
-                logger.info(f"\nTIMESTEP {t} ({minutes} minutes) METRICS:")
-                logger.info(f"{'Obs Thr':>8} {'Best Pred':>10} {'CSI':>8} {'POD':>8} {'FAR':>8} {'Bias':>8}")
-                logger.info("-" * 60)
-                for metric in metrics:
-                    logger.info(f"{metric['obs_threshold']:>7.0f}mm {metric['best_pred_threshold']:>9.1f}mm "
-                               f"{metric['CSI']:>8.3f} {metric['POD']:>8.3f} {metric['FAR']:>8.3f} {metric['Bias']:>8.2f}")
-
-# ---------------- Main ----------------
-def main():
-    cfg = Config()
-    logger.info("="*80)
-    logger.info("EVALUATE MESH MODELS - 60-MINUTE SWATH TARGET (MULTI-CHANNEL)")
-    logger.info("="*80)
-    logger.info(f"Model Dir:     {cfg.MODEL_DIR}")
-    logger.info(f"Model Pattern: {cfg.MODEL_PATTERN}")
-    logger.info(f"Test CSV:      s3://{cfg.TEST_DF_BUCKET}/{cfg.TEST_DF_PATH}")
-    logger.info(f"Samples:       {cfg.NUM_SAMPLES}")
-    logger.info(f"Target:        60-minute MESH swath")
-    logger.info("="*80)
-
-    # Create base directories
-    os.makedirs(cfg.DATA_CACHE_ROOT, exist_ok=True)
-    os.makedirs(cfg.RESULTS_ROOT, exist_ok=True)
-
-    # Initialize evaluator
-    ev = ModelEvaluator(cfg)
-    
-    # Load normalization parameters once (shared across all models)
-    if not ev.load_norm():  
-        logger.error("Failed to load normalization parameters")
-        return
-
-    # Find all models matching the pattern
-    model_paths = find_local_models(cfg.MODEL_DIR, cfg.MODEL_PATTERN)
-    
-    if not model_paths:
-        logger.error(f"No models found matching pattern: {os.path.join(cfg.MODEL_DIR, cfg.MODEL_PATTERN)}")
-        return
-    
-    logger.info(f"\nFound {len(model_paths)} models to evaluate:")
-    for i, path in enumerate(model_paths, 1):
-        logger.info(f"  {i}. {path}")
-    logger.info("")
-
-    # Track results across all models
-    all_results = []
-    successful_models = 0
-    failed_models = 0
-    
-    # Evaluate each model
-    for i, model_path in enumerate(model_paths, 1):
-        logger.info("\n" + "="*80)
-        logger.info(f"EVALUATING MODEL {i}/{len(model_paths)}")
-        logger.info("="*80)
-        
-        try:
-            # Load model
-            if not ev.load_model(model_path):
-                logger.error(f"Failed to load model: {model_path}")
-                failed_models += 1
-                continue
-            
-            # Run evaluation
-            results = ev.evaluate()
-            if not results:
-                logger.error(f"No results produced for model: {model_path}")
-                failed_models += 1
-                continue
-            
-            # Save individual model results
-            ts = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
-            out_json = os.path.join(cfg.RESULTS_DIR, f"results_60min_swath_{ts}.json")
-            with open(out_json, "w") as f:
-                json.dump(results, f, indent=2)
-            logger.info(f"\nResults saved to: {out_json}")
-            
-            # Save summary CSV
-            if 'overall' in results.get('metrics_by_timestep', {}):
-                overall_df = pd.DataFrame(results['metrics_by_timestep']['overall']['best_metrics'])
-                csv_path = os.path.join(cfg.RESULTS_DIR, f"overall_metrics_{ts}.csv")
-                overall_df.to_csv(csv_path, index=False)
-                logger.info(f"Overall metrics CSV saved to: {csv_path}")
-            
-            # Add to combined results
-            all_results.append({
-                'model_path': model_path,
-                'model_name': cfg.MODEL_NAME,
-                'model_channels': ev.model_channels,
-                'results': results
-            })
-            successful_models += 1
-            
-        except Exception as e:
-            logger.error(f"Error evaluating model {model_path}: {e}", exc_info=True)
-            failed_models += 1
+    key_timesteps = [0, 6, 11]
+    for timestep in key_timesteps:
+        key = f"timestep_{timestep}"
+        if key not in result["metrics"]:
             continue
-    
-    # Save combined results summary
-    logger.info("\n" + "="*80)
-    logger.info("EVALUATION COMPLETE - ALL MODELS")
-    logger.info("="*80)
-    logger.info(f"Total models:      {len(model_paths)}")
-    logger.info(f"Successful:        {successful_models}")
-    logger.info(f"Failed:            {failed_models}")
-    
-    if all_results:
-        # Create combined summary
-        combined_summary = {
-            'evaluation_datetime': datetime.utcnow().isoformat(),
-            'total_models': len(model_paths),
-            'successful_models': successful_models,
-            'failed_models': failed_models,
-            'model_directory': cfg.MODEL_DIR,
-            'model_pattern': cfg.MODEL_PATTERN,
-            'num_samples_per_model': cfg.NUM_SAMPLES,
-            'models': []
-        }
-        
-        # Extract key metrics for each model
-        for result in all_results:
-            model_info = {
-                'model_path': result['model_path'],
-                'model_name': result['model_name'],
-                'channels': result['model_channels'],
-                'successful_samples': result['results'].get('successful_samples', 0),
-                'failed_samples': result['results'].get('failed_samples', 0)
-            }
-            
-            # Add overall best metrics
-            if 'overall' in result['results'].get('metrics_by_timestep', {}):
-                overall_metrics = result['results']['metrics_by_timestep']['overall']['best_metrics']
-                # Extract CSI at key thresholds
-                model_info['best_metrics'] = {
-                    f"csi_at_{int(m['obs_threshold'])}mm": m['CSI'] 
-                    for m in overall_metrics
-                }
-            
-            combined_summary['models'].append(model_info)
-        
-        # Save combined summary
-        combined_path = os.path.join(cfg.RESULTS_ROOT, f"combined_summary_{datetime.utcnow().strftime('%Y%m%d_%H%M%S')}.json")
-        with open(combined_path, 'w') as f:
-            json.dump(combined_summary, f, indent=2)
-        logger.info(f"\nCombined summary saved to: {combined_path}")
-        
-        # Create comparison table
-        comparison_rows = []
-        for model_info in combined_summary['models']:
-            row = {
-                'Model': model_info['model_name'],
-                'Channels': model_info['channels'],
-                'Success': model_info['successful_samples'],
-                'Failed': model_info['failed_samples']
-            }
-            if 'best_metrics' in model_info:
-                for key, val in model_info['best_metrics'].items():
-                    row[key.replace('csi_at_', 'CSI@')] = f"{val:.3f}"
-            comparison_rows.append(row)
-        
-        comparison_df = pd.DataFrame(comparison_rows)
-        comparison_csv = os.path.join(cfg.RESULTS_ROOT, f"model_comparison_{datetime.utcnow().strftime('%Y%m%d_%H%M%S')}.csv")
-        comparison_df.to_csv(comparison_csv, index=False)
-        logger.info(f"Model comparison CSV saved to: {comparison_csv}")
-        
-        # Print comparison table
-        logger.info("\n" + "="*80)
-        logger.info("MODEL COMPARISON")
-        logger.info("="*80)
-        logger.info("\n" + comparison_df.to_string(index=False))
-    
-    logger.info("\n" + "="*80)
-    logger.info("EVALUATION SCRIPT COMPLETE")
-    logger.info("="*80)
+        summary = result["metrics"][key]
+        minutes = timestep * 5
+        print("-" * 60)
+        print(f"Timestep {timestep} ({minutes} minutes)")
+        print(f"{'Obs Thr':>8} {'Best Pred':>10} {'CSI':>8} {'POD':>8} {'FAR':>8} {'Bias':>8}")
+        for record in summary.best_metrics:
+            print(
+                f"{record['obs_threshold']:>7.0f}mm {record['best_pred_threshold']:>9.1f}mm "
+                f"{record['CSI']:>8.3f} {record['POD']:>8.3f} {record['FAR']:>8.3f} {record['Bias']:>8.3f}"
+            )
+
 
 if __name__ == "__main__":
     main()

--- a/evaluation/__init__.py
+++ b/evaluation/__init__.py
@@ -1,0 +1,33 @@
+"""Reusable evaluation utilities for MESH verification scripts."""
+
+from .config import EvaluationConfig, StandaloneConfig, MeshEvaluationConfig
+from .data import (
+    S3ArtifactLoader,
+    NormalizationBundle,
+    EvaluationDataRepository,
+    infer_target_key,
+)
+from .metrics import CSIMetricsCalculator
+from .models import ModelType, ModelLoader, LoadedModel
+from .predictors import PredictorFactory
+from .plotting import plot_ground_truth_prediction_difference
+from .standalone_runner import StandaloneVerifier
+from .mesh_runner import MeshEvaluator
+
+__all__ = [
+    "EvaluationConfig",
+    "StandaloneConfig",
+    "MeshEvaluationConfig",
+    "S3ArtifactLoader",
+    "NormalizationBundle",
+    "EvaluationDataRepository",
+    "infer_target_key",
+    "CSIMetricsCalculator",
+    "ModelType",
+    "ModelLoader",
+    "LoadedModel",
+    "PredictorFactory",
+    "plot_ground_truth_prediction_difference",
+    "StandaloneVerifier",
+    "MeshEvaluator",
+]

--- a/evaluation/config.py
+++ b/evaluation/config.py
@@ -1,0 +1,46 @@
+"""Configuration dataclasses shared across evaluation entry-points."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+DEFAULT_BUCKET = "dev-grib-bucket"
+DEFAULT_TEST_DF_KEY = "dataframes/test.csv"
+DEFAULT_NORM_MIN_KEY = "global_mins.npy"
+DEFAULT_NORM_MAX_KEY = "global_maxs.npy"
+
+
+@dataclass
+class EvaluationConfig:
+    """Base configuration for loading evaluation assets."""
+
+    bucket: str = DEFAULT_BUCKET
+    test_df_key: str = DEFAULT_TEST_DF_KEY
+    norm_min_key: str = DEFAULT_NORM_MIN_KEY
+    norm_max_key: str = DEFAULT_NORM_MAX_KEY
+    model_path: Optional[str] = None
+    model_type: Optional[str] = None
+    n_tiles: Optional[int] = None
+    flow_steps: int = 64
+
+    def resolved_model_path(self) -> Optional[str]:
+        return self.model_path
+
+
+@dataclass
+class StandaloneConfig(EvaluationConfig):
+    """Configuration specific to standalone verification runs."""
+
+    datetimes: List[str] = field(default_factory=list)
+    plot_dir: Optional[str] = None
+    plot: bool = True
+    save_plots: bool = True
+
+
+@dataclass
+class MeshEvaluationConfig(EvaluationConfig):
+    """Configuration for mesh-wide CSI evaluation."""
+
+    save_summary: bool = True
+    summary_dir: str = "./evaluation_results"

--- a/evaluation/data.py
+++ b/evaluation/data.py
@@ -1,0 +1,232 @@
+"""Data access helpers for evaluation scripts."""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from io import BytesIO
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+import boto3
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+# Channels to min/max normalize (mask channel index 7 excluded)
+DEFAULT_NORMALIZED_CHANNELS: Tuple[int, ...] = (0, 1, 2, 3, 4, 5, 6)
+
+
+class S3ArtifactLoader:
+    """Load numpy arrays and CSV data from S3 with optional local caching."""
+
+    def __init__(self, cache_dir: str = "./cache", session: Optional[boto3.session.Session] = None):
+        self._session = session or boto3.session.Session()
+        self._s3 = self._session.client("s3")
+        self._cache_dir = cache_dir
+        os.makedirs(self._cache_dir, exist_ok=True)
+
+    def _cache_path(self, bucket: str, key: str, suffix: str) -> str:
+        safe_key = key.replace("/", "_")
+        path = os.path.join(self._cache_dir, bucket, f"{safe_key}{suffix}")
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        return path
+
+    def load_numpy(self, bucket: str, key: str) -> Optional[np.ndarray]:
+        cache_path = self._cache_path(bucket, key, ".npy")
+        if os.path.exists(cache_path):
+            try:
+                return np.load(cache_path)
+            except Exception:
+                logger.warning("Failed to read cached numpy %s; refreshing", cache_path)
+                try:
+                    os.remove(cache_path)
+                except OSError:
+                    pass
+        try:
+            obj = self._s3.get_object(Bucket=bucket, Key=key)
+            data = obj["Body"].read()
+            arr = np.load(BytesIO(data))
+            with open(cache_path, "wb") as fp:
+                fp.write(data)
+            return arr
+        except Exception as exc:
+            logger.error("Unable to load numpy from s3://%s/%s: %s", bucket, key, exc)
+            return None
+
+    def load_csv(self, bucket: str, key: str) -> Optional[pd.DataFrame]:
+        cache_path = self._cache_path(bucket, key, ".csv")
+        if os.path.exists(cache_path):
+            try:
+                return pd.read_csv(cache_path)
+            except Exception:
+                logger.warning("Failed to read cached csv %s; refreshing", cache_path)
+                try:
+                    os.remove(cache_path)
+                except OSError:
+                    pass
+        try:
+            obj = self._s3.get_object(Bucket=bucket, Key=key)
+            data = obj["Body"].read()
+            df = pd.read_csv(BytesIO(data))
+            df.to_csv(cache_path, index=False)
+            return df
+        except Exception as exc:
+            logger.error("Unable to load csv from s3://%s/%s: %s", bucket, key, exc)
+            return None
+
+
+@dataclass
+class NormalizationBundle:
+    """Holds global normalization arrays and applies them to inputs."""
+
+    global_min: np.ndarray
+    global_max: np.ndarray
+    normalized_channels: Tuple[int, ...] = DEFAULT_NORMALIZED_CHANNELS
+
+    @classmethod
+    def from_loader(
+        cls,
+        loader: S3ArtifactLoader,
+        bucket: str,
+        min_key: str,
+        max_key: str,
+    ) -> "NormalizationBundle":
+        gmin = loader.load_numpy(bucket, min_key)
+        gmax = loader.load_numpy(bucket, max_key)
+        if gmin is None or gmax is None:
+            raise ValueError("Failed to load normalization arrays from S3")
+        return cls(global_min=gmin.astype(np.float32), global_max=gmax.astype(np.float32))
+
+    def normalize(self, sample: np.ndarray) -> np.ndarray:
+        sample = np.asarray(sample, dtype=np.float32)
+        if sample.ndim != 4:
+            raise ValueError(f"Expected input with shape (T, H, W, C); got {sample.shape}")
+        normalized = np.zeros_like(sample, dtype=np.float32)
+        for c in range(sample.shape[-1]):
+            channel_slice = sample[..., c]
+            if c in self.normalized_channels:
+                min_val = float(self.global_min[c])
+                max_val = float(self.global_max[c])
+                denom = max(max_val - min_val, 1e-5)
+                norm = (channel_slice - min_val) / denom
+                norm = np.clip(norm, 1e-5, 1.0)
+                normalized[..., c] = norm.astype(np.float32)
+            else:
+                normalized[..., c] = channel_slice
+        return normalized
+
+
+def infer_target_key(input_key: str) -> str:
+    """Infer the target key given an input key following project conventions."""
+    if "/input/" in input_key:
+        return input_key.replace("/input/", "/mesh_swath_intervals/")
+    if "input/" in input_key:
+        return input_key.replace("input/", "mesh_swath_intervals/")
+    if "input" in input_key:
+        suffix = input_key.split("input", 1)[1]
+        return f"data/int5/mesh_swath_intervals{suffix}"
+    base = os.path.basename(input_key)
+    return input_key.replace(base, f"mesh_swath_intervals_{base}")
+
+
+class EvaluationDataRepository:
+    """Wraps S3 access plus dataframe filtering utilities."""
+
+    def __init__(self, loader: S3ArtifactLoader, bucket: str, dataframe_key: str):
+        self.loader = loader
+        self.bucket = bucket
+        self.dataframe_key = dataframe_key
+
+    def load_index(self) -> pd.DataFrame:
+        df = self.loader.load_csv(self.bucket, self.dataframe_key)
+        if df is None:
+            raise RuntimeError(
+                f"Unable to load evaluation dataframe from s3://{self.bucket}/{self.dataframe_key}"
+            )
+        return df
+
+    @staticmethod
+    def _candidate_datetime_columns(df: pd.DataFrame) -> List[str]:
+        cols = []
+        for col in df.columns:
+            lower = col.lower()
+            if "date" in lower or "time" in lower:
+                cols.append(col)
+        return cols
+
+    @staticmethod
+    def _normalize_datetimes(values: Sequence[str]) -> Tuple[List[pd.Timestamp], List[str]]:
+        normalized: List[pd.Timestamp] = []
+        raw_strings: List[str] = []
+        for value in values:
+            if not value:
+                continue
+            raw = value.strip()
+            raw_strings.append(raw)
+            try:
+                normalized.append(pd.to_datetime(raw, utc=True))
+            except Exception:
+                logger.warning("Failed to parse datetime filter '%s'", raw)
+        return normalized, raw_strings
+
+    def filter_by_datetimes(self, df: pd.DataFrame, datetimes: Sequence[str]) -> pd.DataFrame:
+        if not datetimes:
+            return df
+        normalized, raw_strings = self._normalize_datetimes(datetimes)
+        if not normalized and not raw_strings:
+            return df
+        candidates = self._candidate_datetime_columns(df)
+        if not candidates:
+            logger.warning("Datetime filters provided but dataframe lacks datetime-like columns")
+            return df.iloc[0:0]
+        mask = pd.Series(False, index=df.index)
+        for column in candidates:
+            series = df[column]
+            parsed = pd.to_datetime(series, utc=True, errors="coerce")
+            if normalized:
+                mask |= parsed.isin(normalized)
+            if raw_strings:
+                mask |= series.astype(str).str.strip().isin(raw_strings)
+        filtered = df[mask]
+        logger.info("Datetime filter reduced rows from %d to %d", len(df), len(filtered))
+        return filtered
+
+    def select_rows(self, n_tiles: Optional[int], datetimes: Sequence[str]) -> pd.DataFrame:
+        df = self.load_index()
+        if datetimes:
+            df = self.filter_by_datetimes(df, datetimes)
+        if df.empty:
+            raise RuntimeError("No samples match the provided filters")
+        if n_tiles is not None and n_tiles > 0:
+            df = df.head(n_tiles)
+        return df.reset_index(drop=True)
+
+    def load_sample(self, row: pd.Series) -> Tuple[np.ndarray, np.ndarray]:
+        input_key = row.get("file_path") or row.get("input_path") or row.get("inputs_path")
+        target_key = row.get("target_path") or row.get("target") or row.get("y_path")
+        if not isinstance(input_key, str) or not input_key.strip():
+            raise RuntimeError("Row is missing an input path column")
+        input_key = input_key.strip()
+        if not isinstance(target_key, str) or not target_key.strip():
+            target_key = infer_target_key(input_key)
+        target_key = target_key.strip()
+        inputs = self.loader.load_numpy(self.bucket, input_key)
+        targets = self.loader.load_numpy(self.bucket, target_key)
+        if inputs is None or targets is None:
+            raise RuntimeError(f"Failed to load arrays for {input_key} / {target_key}")
+        if inputs.ndim < 4:
+            inputs = np.expand_dims(inputs, axis=-1)
+        inputs = inputs.astype(np.float32)
+        if targets.ndim == 2:
+            targets = targets[np.newaxis, :, :, np.newaxis]
+        elif targets.ndim == 3:
+            if targets.shape[0] >= inputs.shape[0]:
+                targets = targets[:, :, :, np.newaxis]
+            else:
+                targets = targets[np.newaxis, :, :, np.newaxis]
+        elif targets.ndim == 4:
+            targets = targets.astype(np.float32)
+        else:
+            raise RuntimeError(f"Unexpected target shape {targets.shape}")
+        return inputs, targets

--- a/evaluation/mesh_runner.py
+++ b/evaluation/mesh_runner.py
@@ -1,0 +1,164 @@
+"""Evaluator that aggregates CSI metrics across the test dataframe."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+
+from .config import MeshEvaluationConfig
+from .data import EvaluationDataRepository, NormalizationBundle
+from .metrics import CSIMetricsCalculator
+from .plotting import plot_ground_truth_prediction_difference
+from .predictors import PredictorFactory
+
+logger = logging.getLogger(__name__)
+
+
+PREDICTION_THRESHOLDS = np.arange(1.0, 61.0, 1.0)
+OBS_THRESHOLDS = np.array([5, 10, 20, 30, 40, 50, 70], dtype=float)
+TIMESTEPS = 12
+INPUT_CHANNELS = 8
+
+
+def _prepare_inputs(normalization: NormalizationBundle, inputs: np.ndarray) -> np.ndarray:
+    arr = np.asarray(inputs, dtype=np.float32)
+    if arr.ndim < 4:
+        arr = arr[..., np.newaxis]
+    arr = arr[::-1, :, :, :]
+    if arr.shape[0] < TIMESTEPS:
+        raise ValueError(f"Expected at least {TIMESTEPS} timesteps; got {arr.shape[0]}")
+    arr = arr[:TIMESTEPS]
+    if arr.shape[-1] < INPUT_CHANNELS:
+        raise ValueError(f"Expected at least {INPUT_CHANNELS} channels; got {arr.shape[-1]}")
+    arr = arr[..., :INPUT_CHANNELS]
+    return normalization.normalize(arr)
+
+
+def _prepare_target(targets: np.ndarray) -> np.ndarray:
+    arr = np.asarray(targets, dtype=np.float32)
+    if arr.ndim == 2:
+        arr = arr[np.newaxis, :, :, np.newaxis]
+    elif arr.ndim == 3:
+        if arr.shape[-1] == 1:
+            arr = arr[np.newaxis, :, :, :]
+        else:
+            arr = arr[:, :, :, np.newaxis]
+    if arr.ndim != 4:
+        raise ValueError(f"Unexpected target shape {arr.shape}")
+    return arr
+
+
+def _target_swath(target_sequence: np.ndarray) -> np.ndarray:
+    if target_sequence.shape[0] >= 1:
+        return target_sequence[-1, :, :, 0]
+    raise ValueError("Target sequence has no timesteps")
+
+
+@dataclass
+class MeshSampleSummary:
+    index: int
+    prediction_stats: Dict[str, float]
+    target_stats: Dict[str, float]
+    plot_path: Optional[str]
+
+
+class MeshEvaluator:
+    def __init__(
+        self,
+        config: MeshEvaluationConfig,
+        repository: EvaluationDataRepository,
+        normalization: NormalizationBundle,
+        loaded_model,
+    ):
+        self.config = config
+        self.repository = repository
+        self.normalization = normalization
+        self.loaded_model = loaded_model
+        self.predictor = PredictorFactory.create(loaded_model, config)
+
+    def evaluate(self) -> Dict[str, Any]:
+        rows = self.repository.select_rows(self.config.n_tiles, datetimes=[])
+        metrics = CSIMetricsCalculator(PREDICTION_THRESHOLDS, OBS_THRESHOLDS)
+        summaries: List[MeshSampleSummary] = []
+        successes = 0
+        failures = 0
+        for idx, row in rows.iterrows():
+            try:
+                inputs, targets = self.repository.load_sample(row)
+                norm_inputs = _prepare_inputs(self.normalization, inputs)
+                target_sequence = _prepare_target(targets)
+                target_swath = _target_swath(target_sequence)
+                prediction = self.predictor.predict(norm_inputs)
+            except Exception as exc:
+                logger.error("Failed to evaluate row %d: %s", idx, exc)
+                failures += 1
+                continue
+
+            successes += 1
+            metrics.update(prediction.sequence, target_swath)
+            pred_stats = {
+                "min": float(np.min(prediction.sequence)),
+                "max": float(np.max(prediction.sequence)),
+                "mean": float(np.mean(prediction.sequence)),
+                "std": float(np.std(prediction.sequence)),
+            }
+            target_stats = {
+                "min": float(np.min(target_swath)),
+                "max": float(np.max(target_swath)),
+                "mean": float(np.mean(target_swath)),
+                "std": float(np.std(target_swath)),
+            }
+
+            plot_path: Optional[str] = None
+            if self.config.save_summary:
+                plot_path = plot_ground_truth_prediction_difference(
+                    ground_truth=target_swath,
+                    prediction=np.squeeze(prediction.final_frame),
+                    title=f"Mesh Eval Tile {idx}",
+                    output_dir=self.config.summary_dir,
+                    filename=f"mesh_tile_{idx:05d}.png",
+                )
+
+            summaries.append(
+                MeshSampleSummary(
+                    index=idx,
+                    prediction_stats=pred_stats,
+                    target_stats=target_stats,
+                    plot_path=plot_path,
+                )
+            )
+
+        metrics_summary = metrics.finalize()
+        result = {
+            "model_type": self.loaded_model.model_type.value,
+            "num_samples": len(rows),
+            "successful": successes,
+            "failed": failures,
+            "metrics": metrics_summary,
+            "samples": summaries,
+        }
+
+        if self.config.save_summary:
+            os.makedirs(self.config.summary_dir, exist_ok=True)
+            summary_path = os.path.join(self.config.summary_dir, "mesh_evaluation.json")
+            serializable = {
+                **{k: v for k, v in result.items() if k not in {"samples"}},
+                "samples": [
+                    {
+                        "index": summary.index,
+                        "prediction_stats": summary.prediction_stats,
+                        "target_stats": summary.target_stats,
+                        "plot_path": summary.plot_path,
+                    }
+                    for summary in summaries
+                ],
+            }
+            with open(summary_path, "w", encoding="utf-8") as fp:
+                json.dump(serializable, fp, indent=2)
+            logger.info("Wrote mesh evaluation summary to %s", summary_path)
+
+        return result

--- a/evaluation/metrics.py
+++ b/evaluation/metrics.py
@@ -1,0 +1,99 @@
+"""CSI metric aggregation helpers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Sequence
+
+import numpy as np
+
+
+@dataclass
+class MetricsSummary:
+    best_metrics: List[Dict[str, float]]
+    csi_surface: np.ndarray
+    pod_surface: np.ndarray
+    far_surface: np.ndarray
+    bias_surface: np.ndarray
+
+
+class CSIMetricsCalculator:
+    """Accumulate CSI statistics per timestep."""
+
+    def __init__(self, prediction_thresholds: Sequence[float], observation_thresholds: Sequence[float]):
+        self.pred_thresholds = np.asarray(prediction_thresholds, dtype=float)
+        self.obs_thresholds = np.asarray(observation_thresholds, dtype=float)
+        P = len(self.pred_thresholds)
+        O = len(self.obs_thresholds)
+        self.timestep_stats: Dict[int, Dict[str, np.ndarray]] = {}
+        for t in range(12):
+            self.timestep_stats[t] = {
+                "tp": np.zeros((P, O), dtype=np.float64),
+                "fp": np.zeros((P, O), dtype=np.float64),
+                "fn": np.zeros((P, O), dtype=np.float64),
+            }
+        self.overall_tp = np.zeros((P, O), dtype=np.float64)
+        self.overall_fp = np.zeros((P, O), dtype=np.float64)
+        self.overall_fn = np.zeros((P, O), dtype=np.float64)
+
+    def update(self, predictions: np.ndarray, target: np.ndarray) -> None:
+        target_flat = target.reshape(-1)
+        for t in range(predictions.shape[0]):
+            pred_flat = predictions[t].reshape(-1)
+            for p_idx, pred_thr in enumerate(self.pred_thresholds):
+                pred_mask = pred_flat >= pred_thr
+                inv_pred_mask = ~pred_mask
+                for o_idx, obs_thr in enumerate(self.obs_thresholds):
+                    obs_mask = target_flat >= obs_thr
+                    tp = np.count_nonzero(pred_mask & obs_mask)
+                    fp = np.count_nonzero(pred_mask & ~obs_mask)
+                    fn = np.count_nonzero(inv_pred_mask & obs_mask)
+                    self.timestep_stats[t]["tp"][p_idx, o_idx] += tp
+                    self.timestep_stats[t]["fp"][p_idx, o_idx] += fp
+                    self.timestep_stats[t]["fn"][p_idx, o_idx] += fn
+                    self.overall_tp[p_idx, o_idx] += tp
+                    self.overall_fp[p_idx, o_idx] += fp
+                    self.overall_fn[p_idx, o_idx] += fn
+
+    @staticmethod
+    def _compute(tp: np.ndarray, fp: np.ndarray, fn: np.ndarray) -> MetricsSummary:
+        denom = tp + fp + fn
+        with np.errstate(divide="ignore", invalid="ignore"):
+            csi = np.where(denom > 0, tp / denom, 0.0)
+            pod = np.where((tp + fn) > 0, tp / (tp + fn), 0.0)
+            far = np.where((tp + fp) > 0, fp / (tp + fp), 0.0)
+            bias = np.where((tp + fn) > 0, (tp + fp) / (tp + fn), 0.0)
+        best_idx = np.argmax(csi, axis=0)
+        records = []
+        for o_idx in range(csi.shape[1]):
+            records.append(
+                {
+                    "obs_threshold": float(o_idx),  # placeholder; replaced later
+                    "best_pred_threshold": float(best_idx[o_idx]),  # placeholder
+                    "CSI": float(csi[best_idx[o_idx], o_idx]),
+                    "POD": float(pod[best_idx[o_idx], o_idx]),
+                    "FAR": float(far[best_idx[o_idx], o_idx]),
+                    "Bias": float(bias[best_idx[o_idx], o_idx]),
+                }
+            )
+        return MetricsSummary(
+            best_metrics=records,
+            csi_surface=csi,
+            pod_surface=pod,
+            far_surface=far,
+            bias_surface=bias,
+        )
+
+    def finalize(self) -> Dict[str, MetricsSummary]:
+        results: Dict[str, MetricsSummary] = {}
+        for t, stats in self.timestep_stats.items():
+            summary = self._compute(stats["tp"], stats["fp"], stats["fn"])
+            for idx, record in enumerate(summary.best_metrics):
+                record["obs_threshold"] = float(self.obs_thresholds[idx])
+                record["best_pred_threshold"] = float(self.pred_thresholds[int(record["best_pred_threshold"])])
+            results[f"timestep_{t}"] = summary
+        overall_summary = self._compute(self.overall_tp, self.overall_fp, self.overall_fn)
+        for idx, record in enumerate(overall_summary.best_metrics):
+            record["obs_threshold"] = float(self.obs_thresholds[idx])
+            record["best_pred_threshold"] = float(self.pred_thresholds[int(record["best_pred_threshold"])])
+        results["overall"] = overall_summary
+        return results

--- a/evaluation/models.py
+++ b/evaluation/models.py
@@ -1,0 +1,121 @@
+"""Model loading utilities."""
+from __future__ import annotations
+
+import importlib
+import inspect
+import logging
+import os
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, Optional
+
+import tensorflow as tf
+from tensorflow import keras as tfk
+
+from . import config as cfg
+
+logger = logging.getLogger(__name__)
+
+
+class ModelType(str, Enum):
+    CONVGRU = "convgru"
+    FLOW = "flow"
+
+    @classmethod
+    def from_string(cls, value: Optional[str]) -> Optional["ModelType"]:
+        if value is None:
+            return None
+        lowered = value.lower()
+        for member in cls:
+            if lowered in {member.value, member.name.lower()}:
+                return member
+        raise ValueError(f"Unknown model type '{value}'")
+
+
+@dataclass
+class LoadedModel:
+    model: tfk.Model
+    model_type: ModelType
+
+
+def _load_flow_custom_objects() -> Dict[str, object]:
+    try:
+        module = importlib.import_module("flow_matching_model")
+    except ImportError:
+        logger.debug("flow_matching_model module not available")
+        return {}
+    names = getattr(module, "__all__", None)
+    if names is None:
+        names = [name for name in dir(module) if not name.startswith("_")]
+    objects: Dict[str, object] = {}
+    for name in names:
+        attr = getattr(module, name)
+        if inspect.isfunction(attr) or inspect.isclass(attr):
+            objects[name] = attr
+    return objects
+
+
+def _convgru_custom_objects() -> Dict[str, object]:
+    from models import weighted_mse, csi
+    from rnn import (
+        reshape_and_stack,
+        slice_to_n_steps,
+        slice_output_shape,
+        ResBlock,
+        WarmUpCosineDecayScheduler,
+        ConvGRU,
+        ConvBlock,
+        ZeroLikeLayer,
+        ReflectionPadding2D,
+        ResGRU,
+        GRUResBlock,
+    )
+
+    return {
+        "loss": weighted_mse(),
+        "weighted_mse": weighted_mse(),
+        "csi": csi,
+        "reshape_and_stack": reshape_and_stack,
+        "slice_to_n_steps": slice_to_n_steps,
+        "slice_output_shape": slice_output_shape,
+        "ResBlock": ResBlock,
+        "WarmUpCosineDecayScheduler": WarmUpCosineDecayScheduler,
+        "ConvGRU": ConvGRU,
+        "ConvBlock": ConvBlock,
+        "ZeroLikeLayer": ZeroLikeLayer,
+        "ReflectionPadding2D": ReflectionPadding2D,
+        "ResGRU": ResGRU,
+        "GRUResBlock": GRUResBlock,
+    }
+
+
+def _custom_objects_for(model_type: ModelType) -> Dict[str, object]:
+    objects = _convgru_custom_objects()
+    if model_type is ModelType.FLOW:
+        objects.update(_load_flow_custom_objects())
+    return objects
+
+
+def _guess_model_type(path: str) -> ModelType:
+    name = os.path.basename(path).lower()
+    if "flow" in name or "diff" in name:
+        return ModelType.FLOW
+    return ModelType.CONVGRU
+
+
+class ModelLoader:
+    """Load either ConvGRU or flow matching checkpoints."""
+
+    def load(self, config: cfg.EvaluationConfig) -> LoadedModel:
+        model_path = config.resolved_model_path()
+        if not model_path:
+            raise ValueError("A local model path must be supplied via --model_path")
+        if not os.path.exists(model_path):
+            raise FileNotFoundError(f"Model file '{model_path}' does not exist")
+
+        explicit_type = ModelType.from_string(config.model_type) if config.model_type else None
+        model_type = explicit_type or _guess_model_type(model_path)
+        custom_objects = _custom_objects_for(model_type)
+        model = tfk.models.load_model(model_path, custom_objects=custom_objects, compile=False)
+        logger.info("Loaded %s model from %s", model_type.value, model_path)
+        return LoadedModel(model=model, model_type=model_type)

--- a/evaluation/plotting.py
+++ b/evaluation/plotting.py
@@ -1,0 +1,51 @@
+"""Plotting utilities for evaluation outputs."""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+def plot_ground_truth_prediction_difference(
+    ground_truth: np.ndarray,
+    prediction: np.ndarray,
+    title: str,
+    output_dir: Optional[str] = None,
+    filename: Optional[str] = None,
+) -> Optional[str]:
+    """Create a GT/prediction/difference comparison plot."""
+    ground_truth = np.asarray(ground_truth)
+    prediction = np.asarray(prediction)
+    difference = prediction - ground_truth
+
+    fig, axes = plt.subplots(1, 3, figsize=(15, 5))
+    for ax, data, subtitle in zip(
+        axes,
+        [ground_truth, prediction, difference],
+        ["Ground Truth", "Prediction", "Prediction - GT"],
+    ):
+        im = ax.imshow(data, cmap="viridis")
+        ax.set_title(subtitle)
+        ax.axis("off")
+        fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04)
+
+    fig.suptitle(title)
+    fig.tight_layout()
+
+    saved_path: Optional[str] = None
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+        filename = filename or f"comparison_{np.random.randint(0, 1_000_000):06d}.png"
+        saved_path = os.path.join(output_dir, filename)
+        fig.savefig(saved_path)
+        logger.info("Saved comparison plot to %s", saved_path)
+    plt.close(fig)
+    return saved_path

--- a/evaluation/predictors.py
+++ b/evaluation/predictors.py
@@ -1,0 +1,82 @@
+"""Prediction helpers for different model families."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Tuple
+
+import numpy as np
+import tensorflow as tf
+
+from .config import EvaluationConfig
+from .models import LoadedModel, ModelType
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PredictionResult:
+    sequence: np.ndarray
+    final_frame: np.ndarray
+
+
+class BasePredictor:
+    def __init__(self, loaded: LoadedModel, config: EvaluationConfig):
+        self.model = loaded.model
+        self.model_type = loaded.model_type
+        self.config = config
+
+    def predict(self, inputs: np.ndarray) -> PredictionResult:
+        raise NotImplementedError
+
+
+class ConvGRUPredictor(BasePredictor):
+    def predict(self, inputs: np.ndarray) -> PredictionResult:
+        batch = np.expand_dims(inputs, axis=0)
+        outputs = self.model.predict(batch, verbose=0)
+        if isinstance(outputs, (list, tuple)):
+            outputs = outputs[0]
+        sequence = np.asarray(outputs, dtype=np.float32)
+        final_frame = sequence[-1]
+        return PredictionResult(sequence=sequence, final_frame=final_frame)
+
+
+class FlowPredictor(BasePredictor):
+    def _integrate_single_timestep(self, condition_batch: np.ndarray, timestep_idx: int) -> np.ndarray:
+        height = condition_batch.shape[2]
+        width = condition_batch.shape[3]
+        state = np.zeros((1, height, width, 1), dtype=np.float32)
+        n_steps = max(1, int(self.config.flow_steps))
+        dt = 1.0 / float(n_steps)
+        times = np.linspace(0.0, 1.0 - dt, n_steps, dtype=np.float32)
+        timestep_idx_arr = np.array([float(timestep_idx)], dtype=np.float32)
+        for t_val in times:
+            t_arr = np.array([t_val], dtype=np.float32)
+            inputs = {
+                "x_t": state,
+                "condition": condition_batch,
+                "t": t_arr,
+                "timestep_idx": timestep_idx_arr,
+            }
+            velocity = self.model.predict(inputs, verbose=0)
+            if isinstance(velocity, (list, tuple)):
+                velocity = velocity[0]
+            state = state + velocity.astype(np.float32) * dt
+        return state[0]
+
+    def predict(self, inputs: np.ndarray) -> PredictionResult:
+        condition = np.expand_dims(inputs.astype(np.float32), axis=0)
+        frames = []
+        for idx in range(inputs.shape[0]):
+            frames.append(self._integrate_single_timestep(condition, idx))
+        sequence = np.stack(frames, axis=0)
+        final_frame = sequence[-1]
+        return PredictionResult(sequence=sequence, final_frame=final_frame)
+
+
+class PredictorFactory:
+    @staticmethod
+    def create(loaded: LoadedModel, config: EvaluationConfig) -> BasePredictor:
+        if loaded.model_type is ModelType.FLOW:
+            return FlowPredictor(loaded, config)
+        return ConvGRUPredictor(loaded, config)

--- a/evaluation/standalone_runner.py
+++ b/evaluation/standalone_runner.py
@@ -1,0 +1,127 @@
+"""Orchestrates standalone verification runs for individual tiles."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+
+from .config import StandaloneConfig
+from .data import EvaluationDataRepository, NormalizationBundle
+from .metrics import CSIMetricsCalculator
+from .plotting import plot_ground_truth_prediction_difference
+from .predictors import PredictionResult, PredictorFactory
+
+logger = logging.getLogger(__name__)
+
+
+PREDICTION_THRESHOLDS = np.arange(1.0, 61.0, 1.0)
+OBS_THRESHOLDS = np.array([5, 10, 20, 30, 40, 50, 70], dtype=float)
+TIMESTEPS = 12
+INPUT_CHANNELS = 8
+
+
+@dataclass
+class SampleEvaluation:
+    index: int
+    metadata: Dict[str, Any]
+    prediction: PredictionResult
+    target_swath: np.ndarray
+    plot_path: Optional[str]
+
+
+class StandaloneVerifier:
+    def __init__(
+        self,
+        config: StandaloneConfig,
+        repository: EvaluationDataRepository,
+        normalization: NormalizationBundle,
+        loaded_model,
+    ):
+        self.config = config
+        self.repository = repository
+        self.normalization = normalization
+        self.loaded_model = loaded_model
+        self.predictor = PredictorFactory.create(loaded_model, config)
+
+    def _prepare_inputs(self, inputs: np.ndarray) -> np.ndarray:
+        arr = np.asarray(inputs, dtype=np.float32)
+        if arr.ndim < 4:
+            arr = arr[..., np.newaxis]
+        arr = arr[::-1, :, :, :]
+        if arr.shape[0] < TIMESTEPS:
+            raise ValueError(f"Expected at least {TIMESTEPS} timesteps; got {arr.shape[0]}")
+        arr = arr[:TIMESTEPS]
+        if arr.shape[-1] < INPUT_CHANNELS:
+            raise ValueError(
+                f"Expected at least {INPUT_CHANNELS} channels; got {arr.shape[-1]}"
+            )
+        arr = arr[..., :INPUT_CHANNELS]
+        return self.normalization.normalize(arr)
+
+    @staticmethod
+    def _prepare_target(targets: np.ndarray) -> np.ndarray:
+        arr = np.asarray(targets, dtype=np.float32)
+        if arr.ndim == 2:
+            arr = arr[np.newaxis, :, :, np.newaxis]
+        elif arr.ndim == 3:
+            if arr.shape[-1] == 1:
+                arr = arr[np.newaxis, :, :, :]
+            else:
+                arr = arr[:, :, :, np.newaxis]
+        if arr.ndim != 4:
+            raise ValueError(f"Unexpected target array shape {arr.shape}")
+        return arr
+
+    def _target_swath(self, target_sequence: np.ndarray) -> np.ndarray:
+        if target_sequence.shape[0] >= 1:
+            return target_sequence[-1, :, :, 0]
+        raise ValueError("Target sequence has no timesteps")
+
+    def evaluate(self) -> Dict[str, Any]:
+        rows = self.repository.select_rows(self.config.n_tiles, self.config.datetimes)
+        metrics = CSIMetricsCalculator(PREDICTION_THRESHOLDS, OBS_THRESHOLDS)
+        evaluations: List[SampleEvaluation] = []
+        for idx, row in rows.iterrows():
+            try:
+                inputs, targets = self.repository.load_sample(row)
+                norm_inputs = self._prepare_inputs(inputs)
+                target_sequence = self._prepare_target(targets)
+                target_swath = self._target_swath(target_sequence)
+                prediction = self.predictor.predict(norm_inputs)
+            except Exception as exc:
+                logger.error("Failed to evaluate row %d: %s", idx, exc)
+                continue
+
+            metrics.update(prediction.sequence, target_swath)
+
+            plot_path: Optional[str] = None
+            if self.config.plot and self.config.save_plots:
+                plot_title = f"Tile {idx} ({self.loaded_model.model_type.value})"
+                plot_path = plot_ground_truth_prediction_difference(
+                    ground_truth=target_swath,
+                    prediction=np.squeeze(prediction.final_frame),
+                    title=plot_title,
+                    output_dir=self.config.plot_dir,
+                    filename=f"tile_{idx:05d}.png",
+                )
+
+            meta = {col: row[col] for col in row.index if isinstance(row[col], (str, int, float))}
+            evaluations.append(
+                SampleEvaluation(
+                    index=idx,
+                    metadata=meta,
+                    prediction=prediction,
+                    target_swath=target_swath,
+                    plot_path=plot_path,
+                )
+            )
+
+        summary = metrics.finalize()
+        return {
+            "model_type": self.loaded_model.model_type.value,
+            "num_samples": len(evaluations),
+            "evaluations": evaluations,
+            "metrics": summary,
+        }

--- a/standalone_verify.py
+++ b/standalone_verify.py
@@ -1,629 +1,110 @@
 #!/usr/bin/env python3
-"""
-Evaluate MESH - 60-minute swath predictions
+"""Run targeted verification for individual tiles using a single model."""
+from __future__ import annotations
 
-Evaluates model predictions against the 60-minute MESH swath target.
-- Loads best_model_intervals.keras
-- Evaluates all 12 prediction timesteps against the 60-minute swath
-- Calculates CSI, POD, FAR, and Bias metrics
-- Finds optimal prediction thresholds for each observation threshold
-"""
-
-import os
-import json
+import argparse
 import logging
-import numpy as np
-import pandas as pd
-import boto3
-from io import BytesIO
-from datetime import datetime
-from typing import Dict, List, Optional, Tuple
+from typing import Optional
 
-# ---------------- TensorFlow / Keras & custom layers ----------------
-import tensorflow as tf
-from tensorflow import keras as tfk
+from evaluation.config import StandaloneConfig
+from evaluation.data import EvaluationDataRepository, NormalizationBundle, S3ArtifactLoader
+from evaluation.models import ModelLoader
+from evaluation.standalone_runner import StandaloneVerifier
 
-# Import custom objects from modules - REQUIRED for model loading
-try:
-    from rnn import (
-        reshape_and_stack, slice_to_n_steps, slice_output_shape,
-        ResBlock, WarmUpCosineDecayScheduler, ConvGRU, ConvBlock,
-        ZeroLikeLayer, ReflectionPadding2D, ResGRU, GRUResBlock
+
+def parse_n_tiles(value: Optional[str]) -> Optional[int]:
+    if value is None:
+        return None
+    lowered = value.strip().lower()
+    if lowered in {"", "all", "everything", "full", "max", "none", "*"}:
+        return None
+    try:
+        parsed = int(lowered)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "--n_tiles must be a positive integer or 'everything'"
+        ) from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("--n_tiles must be positive")
+    return parsed
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model_path", required=True, help="Path to the model checkpoint to evaluate")
+    parser.add_argument("--model_type", choices=["convgru", "flow"], help="Explicitly specify the model type")
+    parser.add_argument("--datetime", dest="datetimes", action="append", default=[],
+                        help="ISO8601 datetime to evaluate (can be provided multiple times)")
+    parser.add_argument("--n_tiles", type=parse_n_tiles, default=None,
+                        help="Number of tiles to load after filtering; defaults to all")
+    parser.add_argument("--flow_steps", type=int, default=64,
+                        help="Euler integration steps for diffusion flow models")
+    parser.add_argument("--bucket", default="dev-grib-bucket", help="S3 bucket containing evaluation assets")
+    parser.add_argument("--test_df_key", default="dataframes/test.csv",
+                        help="S3 key for the dataframe listing evaluation tiles")
+    parser.add_argument("--norm_min_key", default="global_mins.npy", help="S3 key for global minima array")
+    parser.add_argument("--norm_max_key", default="global_maxs.npy", help="S3 key for global maxima array")
+    parser.add_argument("--cache_dir", default="./cache", help="Local directory for cached downloads")
+    parser.add_argument("--plot_dir", default="./verification_plots", help="Directory to write comparison plots")
+    parser.add_argument("--no_plots", action="store_true", help="Disable writing comparison plots")
+    parser.add_argument("--log_level", default="INFO", help="Logging level")
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO),
+                        format="%(asctime)s - %(levelname)s - %(message)s")
+
+    config = StandaloneConfig(
+        bucket=args.bucket,
+        test_df_key=args.test_df_key,
+        norm_min_key=args.norm_min_key,
+        norm_max_key=args.norm_max_key,
+        model_path=args.model_path,
+        model_type=args.model_type,
+        n_tiles=args.n_tiles,
+        flow_steps=args.flow_steps,
+        datetimes=args.datetimes,
+        plot_dir=None if args.no_plots else args.plot_dir,
+        plot=not args.no_plots,
+        save_plots=not args.no_plots,
     )
-    from models import weighted_mse, csi, focal_mse, combined_loss
-    logger.info("Successfully imported custom objects from rnn and models modules")
-except ImportError as e:
-    logger.error(f"CRITICAL: Cannot import required modules - {e}")
-    logger.error("Make sure rnn.py and models.py are in the same directory or in PYTHONPATH")
-    raise ImportError("Required modules rnn.py and models.py not found. These are required for model loading.")
 
-# ---------------- Channel indices ----------------
-C_MESH60    = 0  # MESH_Max_60min (target channel)
-C_MESH      = 1  # MESH (raw)
-C_HCR       = 2  # HeightCompositeReflectivity
-C_ECHOTOP50 = 3  # EchoTop_50
-C_PRECIP    = 4  # PrecipRate
-C_REF0C     = 5  # Reflectivity_0C
-C_REFm20    = 6  # Reflectivity_-20C
-C_MESH_DIL  = 7  # MESH dil mask (binary)
-NORM_CHANNELS = (C_MESH60, C_MESH, C_HCR, C_ECHOTOP50, C_PRECIP, C_REF0C, C_REFm20)
+    loader = S3ArtifactLoader(cache_dir=args.cache_dir)
+    normalization = NormalizationBundle.from_loader(loader, config.bucket, config.norm_min_key, config.norm_max_key)
+    repository = EvaluationDataRepository(loader, config.bucket, config.test_df_key)
+    loaded_model = ModelLoader().load(config)
+    verifier = StandaloneVerifier(config, repository, normalization, loaded_model)
+    result = verifier.evaluate()
 
-# ---------------- Logging ----------------
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(levelname)s - %(message)s',
-    handlers=[logging.StreamHandler()]
-)
-logger = logging.getLogger("evaluate_mesh_60min")
+    print(f"Model type: {result['model_type']}")
+    print(f"Evaluated samples: {result['num_samples']}")
 
-# ---------------- Config ----------------
-class Config:
-    # Buckets / paths
-    MODEL_BUCKET       = os.getenv('MODEL_BUCKET', 'dev-grib-bucket')
-    TEST_DF_BUCKET     = os.getenv('TEST_DF_BUCKET', MODEL_BUCKET)
-    MODEL_S3_PATH      = os.getenv('MODEL_S3_PATH', 'models/best_model_intervals.keras')
-    TEST_DF_PATH       = os.getenv('TEST_DF_PATH', 'dataframes/test.csv')
-    NORMALIZATION_MIN_PATH = os.getenv('NORMALIZATION_MIN_PATH', 'global_mins3.npy')
-    NORMALIZATION_MAX_PATH = os.getenv('NORMALIZATION_MAX_PATH', 'global_maxs3.npy')
+    evaluations = result["evaluations"]
+    for sample in evaluations:
+        print("-" * 60)
+        print(f"Tile index: {sample.index}")
+        if sample.metadata:
+            for key, value in sample.metadata.items():
+                print(f"  {key}: {value}")
+        print(f"  Plot: {sample.plot_path}")
+        final_frame = sample.prediction.final_frame.squeeze()
+        print(f"  Prediction stats -> min: {final_frame.min():.3f}, max: {final_frame.max():.3f}, mean: {final_frame.mean():.3f}")
 
-    # Writable roots
-    RESULTS_ROOT      = os.getenv('RESULTS_ROOT', './evaluation_results')
-    MODEL_CACHE_ROOT  = os.getenv('MODEL_CACHE_ROOT', './model_cache')
-    DATA_CACHE_ROOT   = os.getenv('DATA_CACHE_ROOT', './data')
-
-    # Eval set
-    NUM_SAMPLES = int(os.getenv('NUM_SAMPLES', '100'))
-
-    # All timesteps (0-11) corresponding to 0-55 minutes in 5-minute intervals
-    TIMESTEPS = np.arange(0, 12)
-    CHANNELS  = np.arange(0, 8)
-
-    # Thresholds (mm)
-    OBS_THRESHOLDS = [5, 10, 20, 30, 40, 50, 70]
-    
-    # Prediction threshold search range
-    PRED_CUTOFF_MIN  = 1.0
-    PRED_CUTOFF_MAX  = 60.0
-    PRED_CUTOFF_STEP = 1.0
-
-    @property
-    def MODEL_NAME(self):
-        return os.path.splitext(os.path.basename(self.MODEL_S3_PATH))[0]
-    @property
-    def MODEL_CACHE_DIR(self):
-        return os.path.join(self.MODEL_CACHE_ROOT, self.MODEL_NAME)
-    @property
-    def RESULTS_DIR(self):
-        return os.path.join(self.RESULTS_ROOT, self.MODEL_NAME)
-
-# ---------------- S3 Loader ----------------
-class DataLoader:
-    def __init__(self, s3, data_root: str):
-        self.s3 = s3
-        self.cache_dir = data_root
-        os.makedirs(self.cache_dir, exist_ok=True)
-
-    def _cache_path(self, bucket: str, key: str) -> str:
-        path = os.path.join(self.cache_dir, bucket, key)
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        return path
-
-    def load_numpy(self, bucket: str, key: str) -> Optional[np.ndarray]:
-        cp = self._cache_path(bucket, key)
-        if os.path.exists(cp):
-            try:
-                return np.load(cp, allow_pickle=False)
-            except Exception:
-                try: os.remove(cp)
-                except Exception: pass
-        try:
-            obj = self.s3.get_object(Bucket=bucket, Key=key)
-            data = obj['Body'].read()
-            with open(cp, 'wb') as f: f.write(data)
-            return np.load(BytesIO(data), allow_pickle=False)
-        except Exception as e:
-            logger.error(f"Failed to load numpy s3://{bucket}/{key}: {e}")
-            return None
-
-    def load_csv(self, bucket: str, key: str) -> Optional[pd.DataFrame]:
-        cp = self._cache_path(bucket, key.replace('/', '_'))
-        if os.path.exists(cp):
-            try:
-                return pd.read_csv(cp)
-            except Exception:
-                try: os.remove(cp)
-                except Exception: pass
-        try:
-            obj = self.s3.get_object(Bucket=bucket, Key=key)
-            data = obj['Body'].read()
-            df = pd.read_csv(BytesIO(data))
-            df.to_csv(cp, index=False)
-            return df
-        except Exception as e:
-            logger.error(f"Failed to load CSV s3://{bucket}/{key}: {e}")
-            return None
-
-    @staticmethod
-    def normalize_inputs(x: np.ndarray, gmins: np.ndarray, gmaxs: np.ndarray) -> np.ndarray:
-        """Normalize channels in NORM_CHANNELS to ~[0,1]; mask stays 0/1."""
-        x = x.astype(np.float32, copy=False)
-        T, H, W, C = x.shape
-        out = np.zeros_like(x, dtype=np.float32)
-        for t in range(T):
-            for c in range(C):
-                arr = x[t, :, :, c]
-                if c in NORM_CHANNELS:
-                    mn, mx = float(gmins[c]), float(gmaxs[c])
-                    if not np.isfinite(mn) or not np.isfinite(mx) or mx <= mn:
-                        mn = float(np.nanmin(arr)) if np.isfinite(np.nanmin(arr)) else 0.0
-                        mx = float(np.nanmax(arr)) if np.isfinite(np.nanmax(arr)) else (mn + 1.0)
-                        if mx <= mn: mx = mn + 1.0
-                    out[t, :, :, c] = np.clip((arr - mn) / (mx - mn + 1e-5), 1e-5, 1.0)
-                else:
-                    out[t, :, :, c] = arr
-        return out
-
-# ---------------- Metrics Calculation ----------------
-class MetricsCalculator:
-    """Calculate metrics for 60-minute swath predictions"""
-    
-    def __init__(self, pred_thresholds, obs_thresholds):
-        self.pred_thr = np.asarray(pred_thresholds, dtype=float)
-        self.obs_thr = np.asarray(obs_thresholds, dtype=float)
-        P, O = len(self.pred_thr), len(self.obs_thr)
-        
-        # Accumulate stats for each timestep separately
-        self.timestep_stats = {}
-        for t in range(12):
-            self.timestep_stats[t] = {
-                'tp': np.zeros((P, O), dtype=np.int64),
-                'fp': np.zeros((P, O), dtype=np.int64),
-                'fn': np.zeros((P, O), dtype=np.int64)
-            }
-        
-        # Also keep overall stats
-        self.overall_tp = np.zeros((P, O), dtype=np.int64)
-        self.overall_fp = np.zeros((P, O), dtype=np.int64)
-        self.overall_fn = np.zeros((P, O), dtype=np.int64)
-
-    def update(self, predictions: np.ndarray, target_60min: np.ndarray):
-        """
-        Update metrics with a single sample's predictions and target.
-        
-        Args:
-            predictions: (12, H, W, 1) - model predictions for each timestep
-            target_60min: (H, W) - 60-minute MESH swath target
-        """
-        target = target_60min.ravel()
-        
-        # Process each timestep
-        for t in range(predictions.shape[0]):
-            pred_t = predictions[t].squeeze().ravel()
-            
-            for p_i, p_thr in enumerate(self.pred_thr):
-                pred_pos = pred_t >= p_thr
-                not_pred = ~pred_pos
-                
-                for o_i, o_thr in enumerate(self.obs_thr):
-                    obs_pos = target >= o_thr
-                    
-                    tp = int(np.count_nonzero(pred_pos & obs_pos))
-                    fp = int(np.count_nonzero(pred_pos & ~obs_pos))
-                    fn = int(np.count_nonzero(not_pred & obs_pos))
-                    
-                    self.timestep_stats[t]['tp'][p_i, o_i] += tp
-                    self.timestep_stats[t]['fp'][p_i, o_i] += fp
-                    self.timestep_stats[t]['fn'][p_i, o_i] += fn
-                    
-                    # Add to overall stats
-                    self.overall_tp[p_i, o_i] += tp
-                    self.overall_fp[p_i, o_i] += fp
-                    self.overall_fn[p_i, o_i] += fn
-
-    def compute_metrics(self, tp, fp, fn):
-        """Compute CSI, POD, FAR, and Bias from counts"""
-        denom = tp + fp + fn
-        with np.errstate(divide='ignore', invalid='ignore'):
-            csi = np.where(denom > 0, tp / denom, 0.0)
-            pod = np.where((tp + fn) > 0, tp / (tp + fn), 0.0)
-            far = np.where((tp + fp) > 0, fp / (tp + fp), 0.0)
-            bias = np.where((tp + fn) > 0, (tp + fp) / (tp + fn), 0.0)
-        return csi, pod, far, bias
-
-    def finalize(self):
-        """Compute final metrics for all timesteps and overall"""
-        results = {}
-        
-        # Compute metrics for each timestep
-        for t in range(12):
-            stats = self.timestep_stats[t]
-            csi, pod, far, bias = self.compute_metrics(stats['tp'], stats['fp'], stats['fn'])
-            
-            # Find best prediction threshold for each observation threshold
-            best_idx = np.argmax(csi, axis=0)
-            best_metrics = pd.DataFrame({
-                "obs_threshold": self.obs_thr,
-                "best_pred_threshold": self.pred_thr[best_idx],
-                "CSI": csi[best_idx, np.arange(len(self.obs_thr))],
-                "POD": pod[best_idx, np.arange(len(self.obs_thr))],
-                "FAR": far[best_idx, np.arange(len(self.obs_thr))],
-                "Bias": bias[best_idx, np.arange(len(self.obs_thr))]
-            })
-            
-            results[f'timestep_{t}'] = {
-                'minutes': t * 5,
-                'best_metrics': best_metrics.to_dict(orient='records'),
-                'csi_surface': csi.tolist(),
-                'pod_surface': pod.tolist(),
-                'far_surface': far.tolist(),
-                'bias_surface': bias.tolist()
-            }
-        
-        # Compute overall metrics (averaged across all timesteps)
-        overall_csi, overall_pod, overall_far, overall_bias = self.compute_metrics(
-            self.overall_tp / 12, self.overall_fp / 12, self.overall_fn / 12
+    metrics = result["metrics"]
+    overall = metrics["overall"]
+    print("=" * 60)
+    print("Overall CSI summary (best thresholds per observation):")
+    print(f"{'Obs Thr':>8} {'Best Pred':>10} {'CSI':>8} {'POD':>8} {'FAR':>8} {'Bias':>8}")
+    for record in overall.best_metrics:
+        print(
+            f"{record['obs_threshold']:>7.0f}mm {record['best_pred_threshold']:>9.1f}mm "
+            f"{record['CSI']:>8.3f} {record['POD']:>8.3f} {record['FAR']:>8.3f} {record['Bias']:>8.3f}"
         )
-        
-        best_idx_overall = np.argmax(overall_csi, axis=0)
-        best_overall = pd.DataFrame({
-            "obs_threshold": self.obs_thr,
-            "best_pred_threshold": self.pred_thr[best_idx_overall],
-            "CSI": overall_csi[best_idx_overall, np.arange(len(self.obs_thr))],
-            "POD": overall_pod[best_idx_overall, np.arange(len(self.obs_thr))],
-            "FAR": overall_far[best_idx_overall, np.arange(len(self.obs_thr))],
-            "Bias": overall_bias[best_idx_overall, np.arange(len(self.obs_thr))]
-        })
-        
-        results['overall'] = {
-            'best_metrics': best_overall.to_dict(orient='records'),
-            'csi_surface': overall_csi.tolist(),
-            'pod_surface': overall_pod.tolist(),
-            'far_surface': overall_far.tolist(),
-            'bias_surface': overall_bias.tolist()
-        }
-        
-        return results
 
-# ---------------- Evaluator ----------------
-class ModelEvaluator:
-    def __init__(self, cfg: Config):
-        self.cfg = cfg
-        self.s3 = boto3.client('s3')
-        self.loader = DataLoader(self.s3, cfg.DATA_CACHE_ROOT)
-        self.model = None
-        self.gmins = None
-        self.gmaxs = None
-
-        for d in (self.cfg.MODEL_CACHE_DIR, self.cfg.RESULTS_DIR):
-            os.makedirs(d, exist_ok=True)
-
-    def load_model(self) -> bool:
-        cache_path = os.path.join(self.cfg.MODEL_CACHE_DIR, f"{self.cfg.MODEL_NAME}.keras")
-        logger.info(f"Model cache path: {cache_path}")
-        try:
-            if not os.path.exists(cache_path):
-                logger.info(f"Downloading model: s3://{self.cfg.MODEL_BUCKET}/{self.cfg.MODEL_S3_PATH}")
-                self.s3.download_file(self.cfg.MODEL_BUCKET, self.cfg.MODEL_S3_PATH, cache_path)
-
-            # Custom objects for model loading - MUST use actual classes from rnn.py and models.py
-            custom_objects = {
-                # Loss functions
-                'loss': weighted_mse(),
-                'weighted_mse': weighted_mse(),
-                'focal_mse': focal_mse(),
-                'combined_loss': combined_loss(),
-                'csi': csi,
-                # Helper functions
-                'reshape_and_stack': reshape_and_stack,
-                'slice_to_n_steps': slice_to_n_steps,
-                'slice_output_shape': slice_output_shape,
-                # Custom layers from rnn.py
-                'ResBlock': ResBlock,
-                'ConvBlock': ConvBlock,
-                'ZeroLikeLayer': ZeroLikeLayer,
-                'ReflectionPadding2D': ReflectionPadding2D,
-                'ConvGRU': ConvGRU,
-                'ResGRU': ResGRU,
-                'GRUResBlock': GRUResBlock,
-                # Learning rate scheduler
-                'WarmUpCosineDecayScheduler': WarmUpCosineDecayScheduler,
-            }
-            
-            # Load model with custom objects
-            self.model = tf.keras.models.load_model(cache_path, custom_objects=custom_objects, compile=False)
-            
-            # Log model info
-            logger.info(f"Loaded model: {self.cfg.MODEL_NAME}")
-            logger.info(f"  Input shape:  {self.model.input_shape}")
-            logger.info(f"  Output shape: {self.model.output_shape}")
-            logger.info(f"  Parameters:   {self.model.count_params():,}")
-            
-            return True
-        except Exception as e:
-            logger.error(f"Model load failed: {e}")
-            logger.error(f"Make sure rnn.py and models.py are in the same directory as this script")
-            return False
-
-    def load_norm(self) -> bool:
-        self.gmins = self.loader.load_numpy(self.cfg.MODEL_BUCKET, self.cfg.NORMALIZATION_MIN_PATH)
-        self.gmaxs = self.loader.load_numpy(self.cfg.MODEL_BUCKET, self.cfg.NORMALIZATION_MAX_PATH)
-        ok = self.gmins is not None and self.gmaxs is not None
-        if not ok:
-            logger.error("Normalization params not found.")
-        else:
-            logger.info(f"Loaded normalization params: mins shape={self.gmins.shape}, maxs shape={self.gmaxs.shape}")
-        return ok
-
-    @staticmethod
-    def _resolve_paths_from_row(row: pd.Series) -> Optional[Tuple[str, str]]:
-        """Resolve input and target paths from dataframe row"""
-        target_key = None
-        for cand in ('target_path', 'target', 'y_path'):
-            if cand in row and isinstance(row[cand], str) and row[cand].strip():
-                target_key = row[cand].strip()
-                break
-
-        input_key = None
-        for cand in ('file_path', 'input_path', 'inputs_path', 'x_path'):
-            if cand in row and isinstance(row[cand], str) and row[cand].strip():
-                input_key = row[cand].strip()
-                break
-
-        if input_key is None and target_key is None:
-            return None
-
-        if target_key is None and input_key is not None:
-            # Try to infer target path from input path
-            if "/input/" in input_key:
-                target_key = input_key.replace("/input/", "/mesh_swath_intervals/")
-            elif "input/" in input_key:
-                target_key = input_key.replace("input/", "mesh_swath_intervals/")
-            else:
-                if "input" in input_key:
-                    suffix = input_key.split("input", 1)[1]
-                    target_key = f"data/int5/mesh_swath_intervals{suffix}"
-                else:
-                    base = os.path.basename(input_key)
-                    target_key = input_key.replace(base, f"mesh_swath_intervals_{base}")
-        
-        return input_key, target_key
-
-    def extract_60min_swath(self, target_array: np.ndarray) -> np.ndarray:
-        """
-        Extract 60-minute MESH swath from target array.
-        The 60-minute swath is typically in channel 0 of the target.
-        """
-        if target_array.ndim == 4:
-            # Shape: (T, H, W, C) - take channel 0 at any timestep (they should be the same)
-            return target_array[0, :, :, 0]
-        elif target_array.ndim == 3:
-            # Shape: (T, H, W) or (H, W, C)
-            if target_array.shape[0] == 12:  # Likely (T, H, W)
-                return target_array[0, :, :]
-            else:  # Likely (H, W, C)
-                return target_array[:, :, 0]
-        elif target_array.ndim == 2:
-            # Already 2D
-            return target_array
-        else:
-            logger.warning(f"Unexpected target shape: {target_array.shape}")
-            return target_array.squeeze()[:, :, 0] if target_array.shape[-1] > 1 else target_array.squeeze()
-
-    def evaluate(self) -> Dict:
-        df = self.loader.load_csv(self.cfg.TEST_DF_BUCKET, self.cfg.TEST_DF_PATH)
-        if df is None or df.empty:
-            logger.error("Empty test dataframe.")
-            return {}
-        
-        # Sample if needed
-        if len(df) > self.cfg.NUM_SAMPLES:
-            df = df.sample(self.cfg.NUM_SAMPLES, random_state=42)
-            logger.info(f"Sampled {self.cfg.NUM_SAMPLES} from {len(df)} total samples")
-        
-        logger.info(f"Evaluating {len(df)} samples against 60-minute MESH swath")
-
-        # Setup metrics calculator
-        pred_cuts = np.arange(self.cfg.PRED_CUTOFF_MIN, self.cfg.PRED_CUTOFF_MAX + 1e-9, self.cfg.PRED_CUTOFF_STEP)
-        obs_thrs = np.array(self.cfg.OBS_THRESHOLDS, dtype=float)
-        
-        metrics_calc = MetricsCalculator(pred_cuts, obs_thrs)
-        
-        # Track statistics
-        successful_samples = 0
-        failed_samples = 0
-        prediction_stats = []
-        target_stats = []
-        
-        # Main evaluation loop
-        for i, (idx, row) in enumerate(df.iterrows(), start=1):
-            if i % 20 == 0:
-                logger.info(f"Progress: {i}/{len(df)} samples")
-
-            resolved = self._resolve_paths_from_row(row)
-            if not resolved:
-                logger.warning(f"Row {idx}: could not resolve paths")
-                failed_samples += 1
-                continue
-            input_key, target_key = resolved
-
-            # Load data
-            x = self.loader.load_numpy(self.cfg.MODEL_BUCKET, input_key)
-            y = self.loader.load_numpy(self.cfg.MODEL_BUCKET, target_key)
-            if x is None or y is None:
-                logger.warning(f"Row {idx}: missing arrays")
-                failed_samples += 1
-                continue
-
-            # Extract 60-minute swath from target
-            target_60min = self.extract_60min_swath(y)
-            
-            # Process input
-            if x.ndim < 4:
-                x = np.expand_dims(x, -1)
-            x = x[::-1, :, :, :]  # reverse time
-            x = x[self.cfg.TIMESTEPS][:, :, :, self.cfg.CHANNELS]
-            
-            # Normalize inputs
-            x = self.loader.normalize_inputs(x, self.gmins, self.gmaxs)
-            x[np.isnan(x)] = 0.0
-            target_60min[np.isnan(target_60min)] = 0.0
-
-            # Predict
-            try:
-                pred = self.model.predict(np.expand_dims(x, 0), verbose=0)  # (1, 12, H, W, 1)
-                pred = pred[0]  # (12, H, W, 1)
-                successful_samples += 1
-            except Exception as e:
-                logger.error(f"Prediction failed for sample {idx}: {e}")
-                failed_samples += 1
-                continue
-
-            # Update metrics
-            metrics_calc.update(pred, target_60min)
-            
-            # Collect statistics
-            prediction_stats.append({
-                'min': float(np.min(pred)),
-                'max': float(np.max(pred)),
-                'mean': float(np.mean(pred)),
-                'std': float(np.std(pred))
-            })
-            target_stats.append({
-                'min': float(np.min(target_60min)),
-                'max': float(np.max(target_60min)),
-                'mean': float(np.mean(target_60min)),
-                'std': float(np.std(target_60min))
-            })
-
-        logger.info(f"Evaluation complete: {successful_samples} successful, {failed_samples} failed")
-
-        # Finalize metrics
-        metrics_results = metrics_calc.finalize()
-        
-        # Compute aggregate statistics
-        if prediction_stats:
-            agg_pred_stats = {
-                'min': float(np.mean([s['min'] for s in prediction_stats])),
-                'max': float(np.mean([s['max'] for s in prediction_stats])),
-                'mean': float(np.mean([s['mean'] for s in prediction_stats])),
-                'std': float(np.mean([s['std'] for s in prediction_stats]))
-            }
-        else:
-            agg_pred_stats = {'min': 0, 'max': 0, 'mean': 0, 'std': 0}
-        
-        if target_stats:
-            agg_target_stats = {
-                'min': float(np.mean([s['min'] for s in target_stats])),
-                'max': float(np.mean([s['max'] for s in target_stats])),
-                'mean': float(np.mean([s['mean'] for s in target_stats])),
-                'std': float(np.mean([s['std'] for s in target_stats]))
-            }
-        else:
-            agg_target_stats = {'min': 0, 'max': 0, 'mean': 0, 'std': 0}
-        
-        # Create final results
-        final_results = {
-            'model': self.cfg.MODEL_NAME,
-            'evaluation_datetime': datetime.utcnow().isoformat(),
-            'num_samples': len(df),
-            'successful_samples': successful_samples,
-            'failed_samples': failed_samples,
-            'target': '60-minute MESH swath',
-            'prediction_statistics': agg_pred_stats,
-            'target_statistics': agg_target_stats,
-            'metrics_by_timestep': metrics_results,
-            'observation_thresholds': self.cfg.OBS_THRESHOLDS,
-            'prediction_threshold_range': {
-                'min': self.cfg.PRED_CUTOFF_MIN,
-                'max': self.cfg.PRED_CUTOFF_MAX,
-                'step': self.cfg.PRED_CUTOFF_STEP
-            }
-        }
-        
-        # Print summary
-        self._print_summary(metrics_results)
-        
-        return final_results
-
-    def _print_summary(self, metrics_results):
-        """Print evaluation summary"""
-        logger.info("\n" + "="*80)
-        logger.info("EVALUATION SUMMARY - 60-MINUTE MESH SWATH")
-        logger.info("="*80)
-        
-        # Print overall metrics
-        overall = metrics_results['overall']['best_metrics']
-        logger.info("\nOVERALL METRICS (averaged across all timesteps):")
-        logger.info(f"{'Obs Thr':>8} {'Best Pred':>10} {'CSI':>8} {'POD':>8} {'FAR':>8} {'Bias':>8}")
-        logger.info("-" * 60)
-        for metric in overall:
-            logger.info(f"{metric['obs_threshold']:>7.0f}mm {metric['best_pred_threshold']:>9.1f}mm "
-                       f"{metric['CSI']:>8.3f} {metric['POD']:>8.3f} {metric['FAR']:>8.3f} {metric['Bias']:>8.2f}")
-        
-        # Print metrics for key timesteps
-        key_timesteps = [0, 6, 11]  # 0, 30, and 55 minutes
-        for t in key_timesteps:
-            timestep_key = f'timestep_{t}'
-            if timestep_key in metrics_results:
-                minutes = metrics_results[timestep_key]['minutes']
-                metrics = metrics_results[timestep_key]['best_metrics']
-                
-                logger.info(f"\nTIMESTEP {t} ({minutes} minutes) METRICS:")
-                logger.info(f"{'Obs Thr':>8} {'Best Pred':>10} {'CSI':>8} {'POD':>8} {'FAR':>8} {'Bias':>8}")
-                logger.info("-" * 60)
-                for metric in metrics:
-                    logger.info(f"{metric['obs_threshold']:>7.0f}mm {metric['best_pred_threshold']:>9.1f}mm "
-                               f"{metric['CSI']:>8.3f} {metric['POD']:>8.3f} {metric['FAR']:>8.3f} {metric['Bias']:>8.2f}")
-
-# ---------------- Main ----------------
-def main():
-    cfg = Config()
-    logger.info("="*80)
-    logger.info("EVALUATE MESH MODEL - 60-MINUTE SWATH TARGET")
-    logger.info("="*80)
-    logger.info(f"Model:     {cfg.MODEL_NAME}")
-    logger.info(f"Model S3:  s3://{cfg.MODEL_BUCKET}/{cfg.MODEL_S3_PATH}")
-    logger.info(f"Test CSV:  s3://{cfg.TEST_DF_BUCKET}/{cfg.TEST_DF_PATH}")
-    logger.info(f"Samples:   {cfg.NUM_SAMPLES}")
-    logger.info(f"Target:    60-minute MESH swath")
-    logger.info(f"Results dir: {cfg.RESULTS_DIR}")
-    logger.info("="*80)
-
-    # Create directories
-    for d in (cfg.MODEL_CACHE_DIR, cfg.RESULTS_DIR, cfg.DATA_CACHE_ROOT):
-        os.makedirs(d, exist_ok=True)
-
-    # Initialize evaluator
-    ev = ModelEvaluator(cfg)
-    
-    # Load model and normalization
-    if not ev.load_model(): 
-        logger.error("Failed to load model")
-        return
-    if not ev.load_norm():  
-        logger.error("Failed to load normalization parameters")
-        return
-
-    # Run evaluation
-    results = ev.evaluate()
-    if not results:
-        logger.error("No results produced.")
-        return
-
-    # Save results
-    os.makedirs(cfg.RESULTS_DIR, exist_ok=True)
-    ts = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
-    out_json = os.path.join(cfg.RESULTS_DIR, f"results_60min_swath_{ts}.json")
-    with open(out_json, "w") as f:
-        json.dump(results, f, indent=2)
-    logger.info(f"\nResults saved to: {out_json}")
-
-    # Save summary CSV for easy viewing
-    if 'overall' in results.get('metrics_by_timestep', {}):
-        overall_df = pd.DataFrame(results['metrics_by_timestep']['overall']['best_metrics'])
-        csv_path = os.path.join(cfg.RESULTS_DIR, f"overall_metrics_{ts}.csv")
-        overall_df.to_csv(csv_path, index=False)
-        logger.info(f"Overall metrics CSV saved to: {csv_path}")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- break the evaluation scripts into a reusable package that covers configuration, S3 data access, model loading, prediction, plotting, and CSI aggregation
- rebuild `standalone_verify.py` as a lean CLI that filters datetimes, normalizes inputs, and plots GT/prediction comparisons for a chosen model
- rework `evaluate_mesh.py` to drive CSI scoring across the test dataframe via the shared runners with optional JSON/plot outputs

## Testing
- python -m compileall evaluation standalone_verify.py evaluate_mesh.py

------
https://chatgpt.com/codex/tasks/task_e_68dfdc8735f883289335858008e2f685