### PR TITLE
Add tile-level debugging to standalone verify

### DIFF
--- a/evaluation/mrms.py
+++ b/evaluation/mrms.py
@@ -262,7 +262,10 @@ class MRMSDataBuilder:
         self,
         target_dt: datetime,
         normalization: NormalizationArrays,
-    ) -> np.ndarray:
+        *,
+        normalize: bool = True,
+        return_raw: bool = False,
+    ) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
         # Normalize once at entry
         target_dt = _as_naive_utc(target_dt)
 
@@ -310,8 +313,13 @@ class MRMSDataBuilder:
                     data[timestep_idx, ..., 7] = self._enlarge_hail_region(array)
 
         self._log_channel_stats("before normalization", data)
-        normalized = self._normalize(data, normalization)
-        self._log_channel_stats("after normalization", normalized)
+        if normalize:
+            normalized = self._normalize(data, normalization)
+            self._log_channel_stats("after normalization", normalized)
+        else:
+            normalized = data.copy()
+        if return_raw:
+            return normalized.copy(), data.copy()
         return normalized
 
     def build_ground_truth(self, target_dt: datetime) -> np.ndarray:


### PR DESCRIPTION
## Summary
- add an `--n_tiles` debugging option to `standalone_verify` that captures per-tile predictions, plots, and input statistics
- align standalone normalization with `evaluate_mesh` by using `NormalizationBundle` and reporting raw vs normalized tile inputs
- extend the MRMS builder to optionally skip normalization and surface raw tensors for analysis

## Testing
- python -m compileall standalone_verify.py evaluation/mrms.py


------
https://chatgpt.com/codex/tasks/task_e_68e03aff8cc48328b568b235118ff69a